### PR TITLE
Renamed make_http_request and improved robustness

### DIFF
--- a/flowsa/common.py
+++ b/flowsa/common.py
@@ -75,7 +75,7 @@ def make_url_request(url, set_cookies=False):
     :param url: URL to query
     :param set_cookies: bool, default set to False
         set to True if cookies required
-    :return: request Object
+    :return: response Object
     """
     session = (requests_ftp.ftp.FTPSession if urlsplit(url).scheme == 'ftp'
                else requests.Session)

--- a/flowsa/common.py
+++ b/flowsa/common.py
@@ -71,7 +71,7 @@ def load_api_key(api_source):
 @memory.cache()
 def make_url_request(url, set_cookies=False):
     """
-    Makes http request using requests library
+    Makes request using requests library if http, or requests_ftp if ftp
     :param url: URL to query
     :param set_cookies: bool, default set to False
         set to True if cookies required

--- a/flowsa/common.py
+++ b/flowsa/common.py
@@ -13,6 +13,7 @@ import pandas as pd
 import numpy as np
 import pycountry
 import joblib
+from urllib.parse import urlsplit
 from dotenv import load_dotenv
 from esupy.processed_data_mgmt import create_paths_if_missing
 from flowsa.schema import flow_by_activity_fields, flow_by_sector_fields, \
@@ -68,7 +69,7 @@ def load_api_key(api_source):
 
 
 @memory.cache()
-def make_http_request(url, set_cookies=False):
+def make_url_request(url, set_cookies=False):
     """
     Makes http request using requests library
     :param url: URL to query
@@ -76,25 +77,21 @@ def make_http_request(url, set_cookies=False):
         set to True if cookies required
     :return: request Object
     """
-    s = requests
-
-    r = []
-    try:
-        r = s.get(url)
-        # determine if require request.post to set cookies
-        if set_cookies:
-            cookies = dict(r.cookies)
-            r = s.post(url, verify=True, cookies=cookies)
-    except requests.exceptions.InvalidSchema:  # if url is ftp rather than http
-        requests_ftp.monkeypatch_session()
-        r = requests.Session().get(url)
-    except requests.exceptions.ConnectionError:
-        log.error("URL Connection Error for %s", url)
-    try:
-        r.raise_for_status()
-    except requests.exceptions.HTTPError:
-        log.error('Error in URL request!')
-    return r
+    session = (requests_ftp.ftp.FTPSession if urlsplit(url).scheme == 'ftp'
+               else requests.Session)
+    with session() as s:
+        try:
+            # The session object s preserves cookies, so the second s.get()
+            # will have the cookies that came from the first s.get()
+            if set_cookies:
+                s.get(url)
+            response = s.get(url)
+            response.raise_for_status()
+        except requests.exceptions.ConnectionError:
+            log.error("URL Connection Error for %s", url)
+        except requests.exceptions.HTTPError:
+            log.error('Error in URL request!')
+    return response
 
 
 def load_crosswalk(crosswalk_name):

--- a/flowsa/data_source_scripts/USGS_SPARROW.py
+++ b/flowsa/data_source_scripts/USGS_SPARROW.py
@@ -7,12 +7,12 @@ Projects
 FLOWSA
 /
 Years = 2012
-Eliminated all columns with fraction in the title. 
+Eliminated all columns with fraction in the title.
 """
 import io
 import pandas as pd
 import xml.etree.ElementTree as ET
-from flowsa.common import make_http_request
+from flowsa.common import make_url_request
 
 
 def url_file(url):
@@ -58,7 +58,7 @@ def column_names(file_name):
     elif file_name in southeastern:
         legend_name = "5d6e70e5e4b0c4f70cf635a1?f=__disk__93%2Fba%2F5c%2F93b" \
                       "a5c50c58ced4116ad2e5b9783fc7848ab2cb5"
-    contents = make_http_request(base_url + legend_name)
+    contents = make_url_request(base_url + legend_name)
     xslt_content = contents.content.decode('utf-8')
     root = ET.fromstring(xslt_content)
     label = []

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -11,7 +11,7 @@ EX: --year 2015 --source USGS_NWIS_WU
 import argparse
 import pandas as pd
 from esupy.processed_data_mgmt import write_df_to_file
-from flowsa.common import log, make_http_request, load_api_key, \
+from flowsa.common import log, make_url_request, load_api_key, \
     load_yaml_dict, rename_log_file
 from flowsa.settings import paths
 from flowsa.metadata import set_fb_meta, write_metadata
@@ -123,7 +123,7 @@ def call_urls(url_list, args, config):
     if url_list[0] is not None:
         for url in url_list:
             log.info("Calling %s", url)
-            r = make_http_request(url, set_cookies=set_cookies)
+            r = make_url_request(url, set_cookies=set_cookies)
             if "call_response_fxn" in config:
                 # dynamically import and call on function
                 df = dynamically_import_fxn(

--- a/scripts/FlowByActivity_Crosswalks/write_Crosswalk_EIA_CBECS.py
+++ b/scripts/FlowByActivity_Crosswalks/write_Crosswalk_EIA_CBECS.py
@@ -11,7 +11,7 @@ Script creates crosswalks for Land and Water
 
 import io
 import pandas as pd
-from flowsa.common import make_http_request
+from flowsa.common import make_url_request
 from flowsa.settings import datapath
 from flowsa.data_source_scripts.EIA_CBECS_Land import standardize_eia_cbecs_land_activity_names
 
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     # url for excel crosswalk
     url = 'http://www.eia.gov/consumption/commercial/data/archive/cbecs/PBAvsNAICS.xls'
     # make url requestl, as defined in common.py
-    r = make_http_request(url)
+    r = make_url_request(url)
     # Convert response to dataframe, skipping first three rows
     df_raw = pd.read_excel(io.BytesIO(r.content), skiprows=3)
 

--- a/scripts/write_FIPS_xwalk_from_Census.py
+++ b/scripts/write_FIPS_xwalk_from_Census.py
@@ -10,9 +10,8 @@ Grabs FIPS codes from static URLs and creates crosswalk over the years.
 
 import io
 import pandas as pd
-from flowsa.common import clean_str_and_capitalize
+from flowsa.common import clean_str_and_capitalize, make_url_request
 from flowsa.settings import datapath
-from flowsa.flowbyactivity import make_http_request
 
 
 def stripcounty(s):
@@ -42,7 +41,7 @@ def annual_fips(years):
             url = "https://www2.census.gov/programs-surveys/popest/geographies/" + \
                   year + "/all-geocodes-v" + year + ".xlsx"
 
-        r = make_http_request(url)
+        r = make_url_request(url)
         raw_df = pd.read_excel(io.BytesIO(r.content)).dropna().reset_index(drop=True)
 
         # skip the first few rows

--- a/scripts/write_Larson_UrbanPublicParks_SI.py
+++ b/scripts/write_Larson_UrbanPublicParks_SI.py
@@ -15,7 +15,7 @@ SI obtained 08/26/2020
 
 import io
 import pandas as pd
-from flowsa.common import make_http_request
+from flowsa.common import make_url_request
 from flowsa.settings import externaldatapath
 
 # 2012--2018 fisheries data at state level
@@ -24,7 +24,7 @@ csv_load = "https://doi.org/10.1371/journal.pone.0153211.s001"
 
 if __name__ == '__main__':
 
-    response = make_http_request(csv_load)
+    response = make_url_request(csv_load)
     # Read directly into a pandas df
     raw_df = pd.read_excel(io.BytesIO(response.content)).dropna().reset_index(drop=True)
     # save data to csv


### PR DESCRIPTION
I renamed the make_http_request() function to reflect the fact that it can handle non-http requests as well. I also tweaked the control flow a bit, using the session as a context manager to ensure that everything is cleaned up when no longer needed, even if errors occur. Additionally, since the only "InvalidSchema" that we can actually handle is ftp, I think it's better to just check for that schema upfront, then use the correct type of session object.