### PR TITLE
`.yaml` inheritance

### DIFF
--- a/flowsa/common.py
+++ b/flowsa/common.py
@@ -86,15 +86,34 @@ def load_crosswalk(crosswalk_name):
 
 def load_yaml_dict(filename):
     """
-    Load the information in 'source_catalog.yaml'
+    Load the information in 'source_catalog.yaml' or source.yaml method file.
     :return: dictionary containing all information in source_catalog.yaml
     """
-    if filename == 'source_catalog':
-        yaml_load = f'{datapath}source_catalog.yaml'
-    else:
-        yaml_load = sourceconfigpath + filename + '.yaml'
-    with open(yaml_load, 'r') as f:
+    folder = datapath if filename == 'source_catalog' else sourceconfigpath
+    yaml_path = folder + filename + '.yaml'
+
+    with open(yaml_path, 'r') as f:
         config = yaml.safe_load(f)
+
+    # Allow for .yaml files to recursively inherit other .yaml files. Keys in
+    # children will overwrite the same key from a parent.
+    inherits = config.get('inherits_from')
+    while inherits:
+        yaml_path = folder + inherits + '.yaml'
+        with open(yaml_path, 'r') as f:
+            parent = yaml.safe_load(f)
+
+        # Check for common keys and log a warning if any are found
+        common_keys = [k for k in config if k in parent]
+        if common_keys:
+            log.warning(f'Keys {common_keys} from parent file {yaml_path} '
+                        f'were overwritten by child file.')
+
+        # Update inheritance information before updating the parent dict
+        inherits = parent.get('inherits_from')
+        parent.update(config)
+        config = parent
+
     return config
 
 

--- a/flowsa/data_source_scripts/BEA.py
+++ b/flowsa/data_source_scripts/BEA.py
@@ -14,12 +14,10 @@ from flowsa.settings import externaldatapath
 from flowsa.flowbyfunctions import assign_fips_location_system
 
 
-def bea_gdp_parse(dataframe_list, args):
+def bea_gdp_parse(*, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -33,7 +31,7 @@ def bea_gdp_parse(dataframe_list, args):
                  var_name="Year",
                  value_name="FlowAmount")
 
-    df = df[df['Year'] == args['year']]
+    df = df[df['Year'] == year]
     # hardcode data
     df["Class"] = "Money"
     df["FlowType"] = "TECHNOSPHERE_FLOW"
@@ -50,16 +48,14 @@ def bea_gdp_parse(dataframe_list, args):
     return df
 
 
-def bea_use_detail_br_parse(dataframe_list, args):
+def bea_use_detail_br_parse(*, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param year: year)
     :return: df, parsed and partially formatted to
         flowbyactivity specifications
     """
-    csv_load = f'{externaldatapath}BEA_{str(args["year"])}' \
+    csv_load = f'{externaldatapath}BEA_{str(year)}' \
                f'_Detail_Use_PRO_BeforeRedef.csv'
     df_raw = pd.read_csv(csv_load)
 
@@ -71,9 +67,9 @@ def bea_use_detail_br_parse(dataframe_list, args):
                  var_name="ActivityConsumedBy",
                  value_name="FlowAmount")
 
-    df['Year'] = str(args['year'])
+    df['Year'] = str(year)
     # hardcode data
-    df['FlowName'] = "USD" + str(args['year'])
+    df['FlowName'] = "USD" + str(year)
     df["Class"] = "Money"
     df["FlowType"] = "TECHNOSPHERE_FLOW"
     df['Description'] = 'BEA_2012_Detail_Code'
@@ -89,17 +85,15 @@ def bea_use_detail_br_parse(dataframe_list, args):
     return df
 
 
-def bea_make_detail_br_parse(dataframe_list, args):
+def bea_make_detail_br_parse(*, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param year: year
     :return: df, parsed and partially formatted to
         flowbyactivity specifications
     """
     # Read directly into a pandas df
-    df_raw = pd.read_csv(externaldatapath + "BEA_" + str(args['year']) +
+    df_raw = pd.read_csv(externaldatapath + "BEA_" + str(year) +
                          "_Detail_Make_BeforeRedef.csv")
 
     # first column is the industry
@@ -110,9 +104,9 @@ def bea_make_detail_br_parse(dataframe_list, args):
                  var_name="ActivityConsumedBy",
                  value_name="FlowAmount")
 
-    df['Year'] = str(args['year'])
+    df['Year'] = str(year)
     # hardcode data
-    df['FlowName'] = "USD" + str(args['year'])
+    df['FlowName'] = "USD" + str(year)
     df["Class"] = "Money"
     df["FlowType"] = "TECHNOSPHERE_FLOW"
     df['Description'] = 'BEA_2012_Detail_Code'
@@ -128,7 +122,7 @@ def bea_make_detail_br_parse(dataframe_list, args):
     return df
 
 
-def bea_make_ar_parse(dataframe_list, args):
+def bea_make_ar_parse(*, year, **_):
     """
     Combine, parse, and format the provided dataframes
     :param dataframe_list: list of dataframes to concat and format
@@ -138,7 +132,7 @@ def bea_make_ar_parse(dataframe_list, args):
         flowbyactivity specifications
     """
     # df = pd.concat(dataframe_list, sort=False)
-    df_load = pd.read_csv(externaldatapath + "BEA_" + args['year'] +
+    df_load = pd.read_csv(externaldatapath + "BEA_" + year +
                           "_Make_AfterRedef.csv", dtype="str")
     # strip whitespace
     df = df_load.apply(lambda x: x.str.strip())
@@ -157,7 +151,7 @@ def bea_make_ar_parse(dataframe_list, args):
     df['SourceName'] = 'BEA_Make_AR'
     df['Unit'] = 'USD'
     df['Location'] = US_FIPS
-    df = assign_fips_location_system(df, args['year'])
+    df = assign_fips_location_system(df, year)
     df['FlowName'] = 'Gross Output Producer Value After Redef'
     df['DataReliability'] = 5  # tmp
     df['DataCollection'] = 5  # tmp
@@ -165,7 +159,7 @@ def bea_make_ar_parse(dataframe_list, args):
     return df
 
 
-def subset_BEA_Use(df, attr, **kwargs):
+def subset_BEA_Use(df, attr, **_):
     """
     Function to modify loaded BEA table based on data in the FBA method yaml
     :param df: df, flowbyactivity format

--- a/flowsa/data_source_scripts/Blackhurst_IO.py
+++ b/flowsa/data_source_scripts/Blackhurst_IO.py
@@ -20,12 +20,12 @@ from flowsa.data_source_scripts.BLS_QCEW import clean_bls_qcew_fba
 from flowsa.validation import compare_df_units
 
 
-def bh_call(url, response_load, args):
+def bh_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
@@ -33,7 +33,7 @@ def bh_call(url, response_load, args):
     pages = range(5, 13)
     bh_df_list = []
     for x in pages:
-        bh_df = tabula.read_pdf(io.BytesIO(response_load.content),
+        bh_df = tabula.read_pdf(io.BytesIO(resp.content),
                                 pages=x, stream=True)[0]
         bh_df_list.append(bh_df)
 
@@ -42,17 +42,15 @@ def bh_call(url, response_load, args):
     return bh_df
 
 
-def bh_parse(dataframe_list, args):
+def bh_parse(*, df_list, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
     :return: df, parsed and partially formatted to
         flowbyactivity specifications
     """
     # concat list of dataframes (info on each page)
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     df = df.rename(columns={"I-O code": "ActivityConsumedBy",
                             "I-O description": "Description",
                             "gal/$M": "FlowAmount",

--- a/flowsa/data_source_scripts/Census_VIP.py
+++ b/flowsa/data_source_scripts/Census_VIP.py
@@ -12,21 +12,18 @@ from flowsa.flowbyfunctions import assign_fips_location_system
 from flowsa.common import US_FIPS
 
 
-def census_vip_call(url, response_load, args):
+def census_vip_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe,
     begin parsing df into FBA format
-    :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
     :return: pandas dataframe of original source data
     """
     # Convert response to dataframe
-    df = pd.read_excel(response_load.content,
+    df = pd.read_excel(resp.content,
                        sheet_name='Total',
                        header=3).dropna().reset_index(drop=True)
-    
+
     df.loc[df['Type of Construction:'].str.startswith("  "),
            'Type of Construction:'] = 'Nonresidential - ' + \
                                       df['Type of Construction:'].str.strip()
@@ -43,28 +40,28 @@ def census_vip_call(url, response_load, args):
                                          df_public['Type of Construction:']
     df_private['Type of Construction:'] = 'Private, ' + \
                                           df_private['Type of Construction:']
-    
+
     df2 = pd.concat([df_public, df_private], ignore_index=True)
-    
+
     df2 = df2.melt(id_vars=['Type of Construction:'],
                    var_name='Year',
                    value_name='FlowAmount')
 
     return df2
-    
 
-def census_vip_parse(dataframe_list, args):
+
+def census_vip_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to
         flowbyactivity specifications
     """
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     df['Year'] = df['Year'].astype(str)
-    df = df[df['Year'] == args['year']].reset_index(drop=True)
+    df = df[df['Year'] == year].reset_index(drop=True)
     df = df.rename(columns={'Type of Construction:': 'ActivityProducedBy'})
 
     df['Class'] = 'Money'
@@ -76,10 +73,10 @@ def census_vip_parse(dataframe_list, args):
     df['FlowType'] = "ELEMENTARY_FLOW"
     df['Compartment'] = None
     df['Location'] = US_FIPS
-    df = assign_fips_location_system(df, args['year'])
-    df['Year'] = args['year']
+    df = assign_fips_location_system(df, year)
+    df['Year'] = year
     # Add tmp DQ scores
     df['DataReliability'] = 5
     df['DataCollection'] = 5
-    
+
     return df

--- a/flowsa/data_source_scripts/EIA_MECS.py
+++ b/flowsa/data_source_scripts/EIA_MECS.py
@@ -21,7 +21,7 @@ from flowsa.data_source_scripts.EIA_CBECS_Land import \
     calculate_total_facility_land_area
 
 
-def eia_mecs_URL_helper(build_url, config, args):
+def eia_mecs_URL_helper(*, build_url, config, year, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url
@@ -43,9 +43,9 @@ def eia_mecs_URL_helper(build_url, config, args):
         # start with build url
         url = build_url
         # replace '__year__' in build url
-        url = url.replace('__year__', args['year'])
+        url = url.replace('__year__', year)
         # 2014 files are in .xlsx format; 2010 files are in .xls format
-        if args['year'] == '2010':
+        if year == '2010':
             url = url[:-1]
         # replace '__table__' in build url
         url = url.replace('__table__', table)
@@ -55,22 +55,22 @@ def eia_mecs_URL_helper(build_url, config, args):
     return urls
 
 
-def eia_mecs_land_call(url, response_load, args):
+def eia_mecs_land_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
     # Convert response to dataframe
-    df_raw_data = pd.read_excel(io.BytesIO(response_load.content),
+    df_raw_data = pd.read_excel(io.BytesIO(resp.content),
                                 sheet_name='Table 9.1')
-    df_raw_rse = pd.read_excel(io.BytesIO(response_load.content),
+    df_raw_rse = pd.read_excel(io.BytesIO(resp.content),
                                sheet_name='RSE 9.1')
-    if args["year"] == "2014":
+    if year == "2014":
         # skip rows and remove extra rows at end of dataframe
         df_rse = pd.DataFrame(df_raw_rse.loc[12:93]).reindex()
         df_data = pd.DataFrame(df_raw_data.loc[16:97]).reindex()

--- a/flowsa/data_source_scripts/EIA_MECS.py
+++ b/flowsa/data_source_scripts/EIA_MECS.py
@@ -164,17 +164,16 @@ def eia_mecs_land_call(*, resp, year, **_):
     return df
 
 
-def eia_mecs_land_parse(dataframe_list, args):
+def eia_mecs_land_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param year: year
     :return: df, parsed and partially formatted to
         flowbyactivity specifications
     """
     df_array = []
-    for dataframes in dataframe_list:
+    for dataframes in df_list:
 
         dataframes = dataframes.rename(
             columns={'NAICS Code(a)': 'ActivityConsumedBy'})
@@ -214,12 +213,12 @@ def eia_mecs_land_parse(dataframe_list, args):
     df.loc[df['FlowAmount'] == "N", 'FlowAmount'] = WITHDRAWN_KEYWORD
     df["Class"] = 'Land'
     df["SourceName"] = 'EIA_MECS_Land'
-    df['Year'] = args["year"]
+    df['Year'] = year
     df["Compartment"] = 'ground'
     df['MeasureofSpread'] = "RSE"
     df['Location'] = US_FIPS
     df['Unit'] = unit
-    df = assign_fips_location_system(df, args['year'])
+    df = assign_fips_location_system(df, year)
     df['FlowType'] = "ELEMENTARY_FLOW"
     df['DataReliability'] = 5  # tmp
     df['DataCollection'] = 5  # tmp
@@ -230,12 +229,12 @@ def eia_mecs_land_parse(dataframe_list, args):
     return df
 
 
-def eia_mecs_energy_call(url, response_load, args):
+def eia_mecs_energy_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin
     parsing df into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
@@ -250,9 +249,9 @@ def eia_mecs_energy_call(url, response_load, args):
 
     # read raw data into dataframe
     # (include both Sheet 1 (data) and Sheet 2 (relative standard errors))
-    df_raw_data = pd.read_excel(io.BytesIO(response_load.content),
+    df_raw_data = pd.read_excel(io.BytesIO(resp.content),
                                 sheet_name=0, header=None)
-    df_raw_rse = pd.read_excel(io.BytesIO(response_load.content),
+    df_raw_rse = pd.read_excel(io.BytesIO(resp.content),
                                sheet_name=1, header=None)
 
     # retrieve table name from cell A3 of Excel file
@@ -267,21 +266,21 @@ def eia_mecs_energy_call(url, response_load, args):
     # - add columns denoting census region, relative standard error, units
     # - concatenate census region data into master dataframe
     df_data = pd.DataFrame()
-    for region in table_dict[args['year']][table]['regions']:
+    for region in table_dict[year][table]['regions']:
 
         # grab relevant columns
         # (this is a necessary step because code was retaining some seemingly
         # blank columns) determine number of columns in table, based on
         # number of column names
-        num_cols = len(table_dict[args['year']][table]['col_names'])
+        num_cols = len(table_dict[year][table]['col_names'])
         # keep only relevant columns
         df_raw_data = df_raw_data.iloc[:, 0:num_cols]
         df_raw_rse = df_raw_rse.iloc[:, 0:num_cols]
 
         # grab relevant rows
         # get indices for relevant rows
-        grab_rows = table_dict[args['year']][table]['regions'][region]
-        grab_rows_rse = table_dict[args['year']][table]['rse_regions'][region]
+        grab_rows = table_dict[year][table]['regions'][region]
+        grab_rows_rse = table_dict[year][table]['rse_regions'][region]
         # keep only relevant rows
         df_data_region = pd.DataFrame(
             df_raw_data.loc[grab_rows[0] - 1:grab_rows[1] - 1]).reindex()
@@ -289,21 +288,21 @@ def eia_mecs_energy_call(url, response_load, args):
             grab_rows_rse[0] - 1:grab_rows_rse[1] - 1]).reindex()
 
         # assign column names
-        df_data_region.columns = table_dict[args['year']][table]['col_names']
-        df_rse_region.columns = table_dict[args['year']][table]['col_names']
+        df_data_region.columns = table_dict[year][table]['col_names']
+        df_rse_region.columns = table_dict[year][table]['col_names']
 
         # "unpivot" dataframe from wide format to long format
         # ('NAICS code' and 'Subsector and Industry' are identifier variables)
         # (all other columns are value variables)
         df_data_region = pd.melt(
             df_data_region,
-            id_vars=table_dict[args['year']][table]['col_names'][0:2],
-            value_vars=table_dict[args['year']][table]['col_names'][2:],
+            id_vars=table_dict[year][table]['col_names'][0:2],
+            value_vars=table_dict[year][table]['col_names'][2:],
             var_name='FlowName', value_name='FlowAmount')
         df_rse_region = pd.melt(
             df_rse_region,
-            id_vars=table_dict[args['year']][table]['col_names'][0:2],
-            value_vars=table_dict[args['year']][table]['col_names'][2:],
+            id_vars=table_dict[year][table]['col_names'][0:2],
+            value_vars=table_dict[year][table]['col_names'][2:],
             var_name='FlowName', value_name='Spread')
 
         # add census region
@@ -323,7 +322,7 @@ def eia_mecs_energy_call(url, response_load, args):
             df_data_region['Unit'] = 'Trillion Btu'
             df_data_region['FlowName'] = df_data_region['FlowName']
 
-        data_type = table_dict[args['year']][table]['data_type']
+        data_type = table_dict[year][table]['data_type']
         if data_type == 'nonfuel consumption':
             df_data_region['Class'] = 'Other'
         elif data_type == 'fuel consumption':
@@ -338,33 +337,33 @@ def eia_mecs_energy_call(url, response_load, args):
     return df_data
 
 
-def eia_mecs_energy_parse(dataframe_list, args):
+def eia_mecs_energy_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param year: year
+    :param source: source
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     from flowsa.common import assign_census_regions
 
     # concatenate dataframe list into single dataframe
-    df = pd.concat(dataframe_list, sort=True)
+    df = pd.concat(df_list, sort=True)
 
     # rename columns to match standard flowbyactivity format
     df = df.rename(columns={'NAICS Code': 'ActivityConsumedBy',
                             'Subsector and Industry': 'Description'})
     df['ActivityConsumedBy'] = df['ActivityConsumedBy'].str.strip()
     # add hardcoded data
-    df["SourceName"] = args['source']
+    df["SourceName"] = source
     df["Compartment"] = None
     df['FlowType'] = 'TECHNOSPHERE_FLOWS'
-    df['Year'] = args["year"]
+    df['Year'] = year
     df['MeasureofSpread'] = "RSE"
     # assign location codes and location system
     df.loc[df['Location'] == 'Total United States', 'Location'] = US_FIPS
-    df = assign_fips_location_system(df, args['year'])
+    df = assign_fips_location_system(df, year)
     df = assign_census_regions(df)
     df.loc[df['Description'] == 'Total', 'ActivityConsumedBy'] = '31-33'
     df['DataReliability'] = 5  # tmp

--- a/flowsa/data_source_scripts/EIA_MER.py
+++ b/flowsa/data_source_scripts/EIA_MER.py
@@ -14,7 +14,7 @@ import pandas as pd
 from flowsa.flowbyfunctions import assign_fips_location_system
 
 
-def eia_mer_url_helper(build_url, config, args):
+def eia_mer_url_helper(*, build_url, config, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url
@@ -23,8 +23,6 @@ def eia_mer_url_helper(build_url, config, args):
     data is obtained.
     :param build_url: string, base url
     :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into
         Flow-By-Activity format
     """
@@ -35,17 +33,14 @@ def eia_mer_url_helper(build_url, config, args):
     return urls
 
 
-def eia_mer_call(url, response_load, args):
+def eia_mer_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe, begin
     parsing df into FBA format
-    :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: response, response from url call
     :return: pandas dataframe of original source data
     """
-    with io.StringIO(response_load.text) as fp:
+    with io.StringIO(resp.text) as fp:
         df = pd.read_csv(fp, encoding="ISO-8859-1")
     return df
 
@@ -93,21 +88,21 @@ def decide_consumed(desc):
     return 'None'
 
 
-def eia_mer_parse(dataframe_list, args):
+def eia_mer_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     # Filter only the rows we want, YYYYMM field beginning with 201,
     # for 2010's.
     # For doing year-by-year based on args['year']
-    min_year = int(args['year'] + '00')
-    max_year = int(str(int(args['year']) + 1) + '00')
+    min_year = int(year + '00')
+    max_year = int(str(int(year) + 1) + '00')
     df = df[df['YYYYMM'] > min_year]
     df = df[df['YYYYMM'] < max_year]
 
@@ -140,7 +135,7 @@ def eia_mer_parse(dataframe_list, args):
 
     output = pd.DataFrame(sums)
 
-    output = assign_fips_location_system(output, args["year"])
+    output = assign_fips_location_system(output, year)
 
     # hard code data
     output['Class'] = 'Energy'

--- a/flowsa/data_source_scripts/EPA_CDDPath.py
+++ b/flowsa/data_source_scripts/EPA_CDDPath.py
@@ -17,18 +17,18 @@ from flowsa.flowbyfunctions import assign_fips_location_system
 
 
 # Read pdf into list of DataFrame
-def epa_cddpath_call(url, response_load, args):
+def epa_cddpath_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe,
     begin parsing df into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
     # Convert response to dataframe
-    df = (pd.io.excel.read_excel(io.BytesIO(response_load.content),
+    df = (pd.io.excel.read_excel(io.BytesIO(resp.content),
                                  sheet_name='Final Results',
                                  # exclude extraneous rows & cols
                                  header=2, nrows=30, usecols="A, B, E",
@@ -44,18 +44,18 @@ def epa_cddpath_call(url, response_load, args):
     return df
 
 
-def epa_cddpath_parse(dataframe_list, args):
+def epa_cddpath_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     # concat list of dataframes (info on each page)
-    df = pd.concat(dataframe_list, sort=False)
-    
+    df = pd.concat(df_list, sort=False)
+
     # hardcode
     df['Class'] = 'Other'  # confirm this
     df['SourceName'] = 'EPA_CDDPath'  # confirm this
@@ -64,8 +64,8 @@ def epa_cddpath_parse(dataframe_list, args):
     df.loc[df['ActivityProducedBy'].isna(), 'ActivityProducedBy'] = 'Buildings'
     # df['Compartment'] = 'waste'  # confirm this
     df['Location'] = US_FIPS
-    df = assign_fips_location_system(df, args['year'])
-    df['Year'] = args['year']
+    df = assign_fips_location_system(df, year)
+    df['Year'] = year
     # df['MeasureofSpread'] = "NA"  # none available
     df['DataReliability'] = 5  # confirm this
     df['DataCollection'] = 5  # confirm this
@@ -90,7 +90,7 @@ def combine_cdd_path(url, response_load, args):
     df_csv = write_cdd_path_from_csv()
     df_excel = epa_cddpath_call(url, response_load, args)
     df_excel = df_excel[~df_excel['FlowName'].isin(df_csv['FlowName'])]
-    
+
     df = pd.concat([df_csv, df_excel], ignore_index=True)
     return df
 
@@ -104,7 +104,7 @@ def assign_wood_to_engineering(df, **kwargs):
     dictionary of FBA method yaml parameters
     :return: df, CDDPath FBA with wood reassigned
     """
-    
+
     # Update wood to a new activity for improved mapping
     df.loc[((df.FlowName == 'Wood') &
            (df.ActivityProducedBy == 'Other')),

--- a/flowsa/data_source_scripts/EPA_CDDPath.py
+++ b/flowsa/data_source_scripts/EPA_CDDPath.py
@@ -82,13 +82,13 @@ def write_cdd_path_from_csv():
     return df
 
 
-def combine_cdd_path(url, response_load, args):
+def combine_cdd_path(*, resp, **_):
     """Call function to generate combined dataframe from csv file and
     excel dataset, bringing only those flows from the excel file that are
     not in the csv file
     """
     df_csv = write_cdd_path_from_csv()
-    df_excel = epa_cddpath_call(url, response_load, args)
+    df_excel = epa_cddpath_call(resp=resp)
     df_excel = df_excel[~df_excel['FlowName'].isin(df_csv['FlowName'])]
 
     df = pd.concat([df_csv, df_excel], ignore_index=True)

--- a/flowsa/data_source_scripts/EPA_GHGI.py
+++ b/flowsa/data_source_scripts/EPA_GHGI.py
@@ -196,7 +196,7 @@ TBL_META = {
 YEARS = ["2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018"]
 
 
-def ghg_url_helper(build_url, config, args):
+def ghg_url_helper(*, build_url, config, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -205,8 +205,6 @@ def ghg_url_helper(build_url, config, args):
     obtained.
     :param build_url: string, base url
     :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -293,19 +291,17 @@ def series_separate_name_and_units(series, default_flow_name, default_units):
     return {'names': names, 'units': units}
 
 
-def ghg_call(url, response_load, args):
+def ghg_call(*, resp, url, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
+    :param resp: df, response from url call
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param year: year
     :return: pandas dataframe of original source data
     """
     df = None
-    year = args['year']
-    with zipfile.ZipFile(io.BytesIO(response_load.content), "r") as f:
+    with zipfile.ZipFile(io.BytesIO(resp.content), "r") as f:
         frames = []
         if 'annex' in url:
             is_annex = True
@@ -414,17 +410,16 @@ def is_consumption(source_name):
     return False
 
 
-def ghg_parse(dataframe_list, args):
+def ghg_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     cleaned_list = []
-    for df in dataframe_list:
+    for df in df_list:
         special_format = False
         source_name = df["SourceName"][0]
         log.info('Processing Source Name %s', source_name)
@@ -456,7 +451,7 @@ def ghg_parse(dataframe_list, args):
         if special_format and "Year" in df.columns:
             id_vars.append("Year")
             # Cast Year column to numeric and delete any years != year
-            df = df[pd.to_numeric(df["Year"], errors="coerce") == int(args['year'])]
+            df = df[pd.to_numeric(df["Year"], errors="coerce") == int(year)]
 
         # Set index on the df:
         df.set_index(id_vars)
@@ -526,7 +521,7 @@ def ghg_parse(dataframe_list, args):
         # Some of the datasets, 4-43 and 4-80, still have years we don't want at this point.
         # Remove rows matching the years we don't want:
         try:
-            df = df[df['Year'].isin([args['year']])]
+            df = df[df['Year'].isin([year])]
         except AttributeError as ex:
             log.info(ex)
 
@@ -538,7 +533,7 @@ def ghg_parse(dataframe_list, args):
         df["DistributionType"] = 'None'
         df["LocationSystem"] = 'None'
 
-        df = assign_fips_location_system(df, str(args['year']))
+        df = assign_fips_location_system(df, str(year))
 
         if is_cons:
             df = df.rename(columns={'FlowName': 'ActivityConsumedBy', 'ActivityConsumedBy': 'FlowName'})

--- a/flowsa/data_source_scripts/EPA_NEI.py
+++ b/flowsa/data_source_scripts/EPA_NEI.py
@@ -131,7 +131,7 @@ def epa_nei_onroad_parse(*, df_list, source, year, **_):
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
-    df = epa_nei_global_parse(df_list, source, year)
+    df = epa_nei_global_parse(df_list=df_list, source=source, year=year)
 
     # Add DQ scores
     df['DataReliability'] = 3
@@ -150,7 +150,7 @@ def epa_nei_nonroad_parse(*, df_list, source, year, **_):
         specifications
     """
 
-    df = epa_nei_global_parse(df_list, source, year)
+    df = epa_nei_global_parse(df_list=df_list, source=source, year=year)
 
     # Add DQ scores
     df['DataReliability'] = 3
@@ -169,7 +169,7 @@ def epa_nei_nonpoint_parse(*, df_list, source, year, **_):
         specifications
     """
 
-    df = epa_nei_global_parse(df_list, source, year)
+    df = epa_nei_global_parse(df_list=df_list, source=source, year=year)
 
     # Add DQ scores
     df['DataReliability'] = 3

--- a/flowsa/data_source_scripts/EPA_NI.py
+++ b/flowsa/data_source_scripts/EPA_NI.py
@@ -93,7 +93,7 @@ def name_and_unit_split(df_legend):
     return df_legend
 
 
-def ni_url_helper(build_url, config, args):
+def ni_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -111,26 +111,26 @@ def ni_url_helper(build_url, config, args):
     return [url]
 
 
-def ni_call(url, response, args):
+def ni_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param response: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_legend = pd.io.excel.read_excel(io.BytesIO(response.content),
+    df_legend = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                        sheet_name='Legend')
-    if args['year'] == '2002':
-        df_raw = pd.io.excel.read_excel(io.BytesIO(response.content),
+    if year == '2002':
+        df_raw = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                         sheet_name='2002')
-    elif args['year'] == '2007':
-        df_raw = pd.io.excel.read_excel(io.BytesIO(response.content),
+    elif year == '2007':
+        df_raw = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                         sheet_name='2007')
     else:
-        df_raw = pd.io.excel.read_excel(io.BytesIO(response.content),
+        df_raw = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                         sheet_name='2012')
 
     for col_name in df_raw.columns:
@@ -157,10 +157,10 @@ def ni_call(url, response, args):
     return df
 
 
-def ni_parse(dataframe_list, args):
+def ni_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -169,10 +169,10 @@ def ni_parse(dataframe_list, args):
     # load arguments necessary for function
 
     df = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         df["Class"] = "Chemicals"
         df["SourceName"] = "EPA_NI"
         df["LocationSystem"] = 'HUC'
-        df["Year"] = str(args["year"])
+        df["Year"] = str(year)
         df["FlowType"] = "ELEMENTARY_FLOW"
     return df

--- a/flowsa/data_source_scripts/NETL_EIA_PlantWater.py
+++ b/flowsa/data_source_scripts/NETL_EIA_PlantWater.py
@@ -14,7 +14,7 @@ from flowsa.settings import externaldatapath
 from flowsa.flowbyfunctions import assign_fips_location_system
 
 
-def netl_eia_parse(dataframe_list, args):
+def netl_eia_parse(*, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
     :param dataframe_list: list of dataframes to concat and format
@@ -25,7 +25,7 @@ def netl_eia_parse(dataframe_list, args):
     """
     # load the csv file
     DATA_FILE = f"NETL-EIA_powerplants_water_withdraw_consume_data_" \
-                f"{args['year']}.csv"
+                f"{year}.csv"
     df_load = pd.read_csv(f"{externaldatapath}{DATA_FILE}",
                           index_col=0, low_memory=False)
 
@@ -137,7 +137,7 @@ def netl_eia_parse(dataframe_list, args):
 
     df4['Class'] = np.where(df4['FlowName'].str.contains('Water|discharge'),
                             "Water", "Energy")
-    df4['SourceName'] = args['source']
+    df4['SourceName'] = source
     df4['DataReliability'] = 1
     df4['DataCollection'] = 5
     df4['FlowType'] = "ELEMENTARY_FLOW"
@@ -147,7 +147,7 @@ def netl_eia_parse(dataframe_list, args):
         columns=['860 Cooling Type 1', 'Generator Primary Technology',
                  'Water Type', 'County', 'State', 'State_y',
                  'Water Source Name'])
-    df4 = assign_fips_location_system(df4, str(args["year"]))
+    df4 = assign_fips_location_system(df4, str(year))
 
     return df4
 

--- a/flowsa/data_source_scripts/NOAA_FisheryLandings.py
+++ b/flowsa/data_source_scripts/NOAA_FisheryLandings.py
@@ -26,12 +26,10 @@ from flowsa.common import get_state_FIPS
 from flowsa.settings import externaldatapath
 
 
-def noaa_parse(dataframe_list, args):
+def noaa_parse(*, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -47,7 +45,7 @@ def noaa_parse(dataframe_list, args):
     df['State'] = df["State"].str.lower()
 
     # filter by year
-    df = df[df['Year'] == int(args['year'])]
+    df = df[df['Year'] == int(year)]
     # noaa differentiates between florida east and west,
     # which is not necessary for our purposes
     df['State'] = df['State'].str.replace(r'-east', '')
@@ -79,7 +77,7 @@ def noaa_parse(dataframe_list, args):
     df4["Class"] = "Money"
     df4["SourceName"] = "NOAA_Landings"
     df4["FlowName"] = None
-    df4 = assign_fips_location_system(df4, args['year'])
+    df4 = assign_fips_location_system(df4, year)
     df4["Unit"] = "$"
     df4["ActivityProducedBy"] = "All Species"
     df4['DataReliability'] = 5  # tmp

--- a/flowsa/data_source_scripts/StatCan_GDP.py
+++ b/flowsa/data_source_scripts/StatCan_GDP.py
@@ -15,19 +15,19 @@ import pandas as pd
 from flowsa.common import call_country_code
 
 
-def sc_gdp_call(url, response_load, args):
+def sc_gdp_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
     # Convert response to dataframe
     # read all files in the stat canada zip
-    with zipfile.ZipFile(io.BytesIO(response_load.content), "r") as f:
+    with zipfile.ZipFile(io.BytesIO(resp.content), "r") as f:
         # read in file names
         for name in f.namelist():
             # if filename does not contain "MetaData", then create dataframe
@@ -37,17 +37,17 @@ def sc_gdp_call(url, response_load, args):
     return df
 
 
-def sc_gdp_parse(dataframe_list, args):
+def sc_gdp_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     # concat dataframes
-    df = pd.concat(dataframe_list, sort=False, ignore_index=True)
+    df = pd.concat(df_list, sort=False, ignore_index=True)
     # drop columns
     df = df.drop(columns=['COORDINATE', 'DECIMALS', 'DGUID', 'SYMBOL',
                           'TERMINATED', 'UOM_ID', 'SCALAR_ID', 'VECTOR',
@@ -78,7 +78,7 @@ def sc_gdp_parse(dataframe_list, args):
     df["DataCollection"] = 4
 
     # drop data
-    df = df[df['Year'] == args['year']]
+    df = df[df['Year'] == year]
     df = df[~df['ActivityProducedBy'].apply(
         lambda x: x[0:1] == 'T')].reset_index(drop=True)
     return df

--- a/flowsa/data_source_scripts/StatCan_IWS_MI.py
+++ b/flowsa/data_source_scripts/StatCan_IWS_MI.py
@@ -16,19 +16,16 @@ from flowsa.common import fba_default_grouping_fields, US_FIPS, \
 from flowsa.validation import compare_df_units
 
 
-def sc_call(url, response_load, args):
+def sc_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe,
     begin parsing df into FBA format
-    :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: response, response from url call
     :return: pandas dataframe of original source data
     """
     # Convert response to dataframe
     # read all files in the stat canada zip
-    with zipfile.ZipFile(io.BytesIO(response_load.content), "r") as f:
+    with zipfile.ZipFile(io.BytesIO(resp.content), "r") as f:
         # read in file names
         for name in f.namelist():
             # if filename does not contain "MetaData", then create dataframe
@@ -38,17 +35,16 @@ def sc_call(url, response_load, args):
     return df
 
 
-def sc_parse(dataframe_list, args):
+def sc_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     # concat dataframes
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     # drop columns
     df = df.drop(columns=['COORDINATE', 'DECIMALS', 'DGUID', 'SYMBOL',
                           'TERMINATED', 'UOM_ID', 'SCALAR_ID', 'VECTOR'])
@@ -96,7 +92,7 @@ def sc_parse(dataframe_list, args):
     df["DataCollection"] = 4
 
     # subset based on year
-    df = df[df['Year'] == args['year']]
+    df = df[df['Year'] == year]
 
     return df
 

--- a/flowsa/data_source_scripts/StatCan_LFS.py
+++ b/flowsa/data_source_scripts/StatCan_LFS.py
@@ -16,19 +16,16 @@ import pandas as pd
 from flowsa.common import WITHDRAWN_KEYWORD
 
 
-def sc_lfs_call(url, response_load, args):
+def sc_lfs_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
-    :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
     :return: pandas dataframe of original source data
     """
     # Convert response to dataframe
     # read all files in the stat canada zip
-    with zipfile.ZipFile(io.BytesIO(response_load.content), "r") as f:
+    with zipfile.ZipFile(io.BytesIO(resp.content), "r") as f:
         # read in file names
         for name in f.namelist():
             # if filename does not contain "MetaData", then create dataframe
@@ -38,17 +35,15 @@ def sc_lfs_call(url, response_load, args):
     return df
 
 
-def sc_lfs_parse(dataframe_list, args):
+def sc_lfs_parse(*, df_list, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     # concat dataframes
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     # drop columns
     df = df.drop(columns=['COORDINATE', 'DECIMALS', 'DGUID', 'SYMBOL',
                           'TERMINATED', 'UOM_ID', 'SCALAR_ID', 'VECTOR'])

--- a/flowsa/data_source_scripts/USDA_CoA_Cropland.py
+++ b/flowsa/data_source_scripts/USDA_CoA_Cropland.py
@@ -24,7 +24,7 @@ from flowsa.sectormapping import add_sectors_to_flowbyactivity
 from flowsa.validation import compare_df_units
 
 
-def CoA_Cropland_URL_helper(build_url, config, args):
+def CoA_Cropland_URL_helper(*, build_url, config, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -33,8 +33,6 @@ def CoA_Cropland_URL_helper(build_url, config, args):
     obtained.
     :param build_url: string, base url
     :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -87,31 +85,31 @@ def CoA_Cropland_URL_helper(build_url, config, args):
     return urls
 
 
-def coa_cropland_call(url, response_load, args):
+def coa_cropland_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    cropland_json = json.loads(response_load.text)
+    cropland_json = json.loads(resp.text)
     df_cropland = pd.DataFrame(data=cropland_json["data"])
     return df_cropland
 
 
-def coa_cropland_parse(dataframe_list, args):
+def coa_cropland_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     # specify desired data based on domain_desc
     df = df[~df['domain_desc'].isin(
         ['ECONOMIC CLASS', 'FARM SALES', 'IRRIGATION STATUS', 'CONCENTRATION',
@@ -233,7 +231,7 @@ def coa_cropland_parse(dataframe_list, args):
     df.loc[df['Spread'] == "", 'Spread'] = None
     df.loc[df['Spread'] == "(D)", 'Spread'] = WITHDRAWN_KEYWORD
     # add location system based on year of data
-    df = assign_fips_location_system(df, args['year'])
+    df = assign_fips_location_system(df, year)
     # Add hardcoded data
     df['Class'] = np.where(df["Unit"] == 'ACRES', "Land", "Other")
     df['SourceName'] = "USDA_CoA_Cropland"

--- a/flowsa/data_source_scripts/USDA_CoA_Cropland_NAICS.py
+++ b/flowsa/data_source_scripts/USDA_CoA_Cropland_NAICS.py
@@ -16,7 +16,7 @@ from flowsa.flowbyfunctions import assign_fips_location_system, \
     equally_allocate_suppressed_parent_to_child_naics
 
 
-def CoA_Cropland_NAICS_URL_helper(build_url, config, args):
+def CoA_Cropland_NAICS_URL_helper(*, build_url, config, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -25,8 +25,6 @@ def CoA_Cropland_NAICS_URL_helper(build_url, config, args):
     obtained.
     :param build_url: string, base url
     :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -57,31 +55,27 @@ def CoA_Cropland_NAICS_URL_helper(build_url, config, args):
     return urls
 
 
-def coa_cropland_NAICS_call(url, response_load, args):
+def coa_cropland_NAICS_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe,
     begin parsing df into FBA format
-    :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
     :return: pandas dataframe of original source data
     """
-    cropland_json = json.loads(response_load.text)
+    cropland_json = json.loads(resp.text)
     df_cropland = pd.DataFrame(data=cropland_json["data"])
     return df_cropland
 
 
-def coa_cropland_NAICS_parse(dataframe_list, args):
+def coa_cropland_NAICS_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     # specify desired data based on domain_desc
     df = df[df['domain_desc'] == 'NAICS CLASSIFICATION']
     # only want ag land and farm operations
@@ -152,7 +146,7 @@ def coa_cropland_NAICS_parse(dataframe_list, args):
     df = df[~df['Description'].str.contains(
         'INSURANCE|OWNED|RENTED|FAILED|FALLOW|IDLE')].reset_index(drop=True)
     # add location system based on year of data
-    df = assign_fips_location_system(df, args['year'])
+    df = assign_fips_location_system(df, year)
     # Add hardcoded data
     df['Class'] = np.where(df["Unit"] == 'ACRES', "Land", "Other")
     df['SourceName'] = "USDA_CoA_Cropland_NAICS"

--- a/flowsa/data_source_scripts/USDA_CoA_Livestock.py
+++ b/flowsa/data_source_scripts/USDA_CoA_Livestock.py
@@ -12,7 +12,7 @@ from flowsa.common import US_FIPS, WITHDRAWN_KEYWORD, abbrev_us_state
 from flowsa.flowbyfunctions import assign_fips_location_system
 
 
-def CoA_Livestock_URL_helper(build_url, config, args):
+def CoA_Livestock_URL_helper(*, build_url, config, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -21,8 +21,6 @@ def CoA_Livestock_URL_helper(build_url, config, args):
     obtained.
     :param build_url: string, base url
     :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -53,32 +51,32 @@ def CoA_Livestock_URL_helper(build_url, config, args):
     return urls_livestock
 
 
-def coa_livestock_call(url, response_load, args):
+def coa_livestock_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    livestock_json = json.loads(response_load.text)
+    livestock_json = json.loads(resp.text)
     # Convert response to dataframe
     df_livestock = pd.DataFrame(data=livestock_json["data"])
     return df_livestock
 
 
-def coa_livestock_parse(dataframe_list, args):
+def coa_livestock_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     # # specify desired data based on domain_desc
     df = df[df['domain_desc'].str.contains("INVENTORY|TOTAL")]
     df = df[~df['domain_desc'].str.contains(
@@ -134,7 +132,7 @@ def coa_livestock_parse(dataframe_list, args):
     df.loc[df['Spread'] == "", 'Spread'] = None
     df.loc[df['Spread'] == "(D)", 'Spread'] = WITHDRAWN_KEYWORD
     # add location system based on year of data
-    df = assign_fips_location_system(df, args['year'])
+    df = assign_fips_location_system(df, year)
     # # Add hardcoded data
     df['Class'] = "Other"
     df['SourceName'] = "USDA_CoA_Livestock"

--- a/flowsa/data_source_scripts/USDA_ERS_FIWS.py
+++ b/flowsa/data_source_scripts/USDA_ERS_FIWS.py
@@ -14,18 +14,15 @@ import pandas as pd
 from flowsa.common import US_FIPS, get_all_state_FIPS_2, us_state_abbrev
 
 
-def fiws_call(url, response_load, args):
+def fiws_call(*, resp, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
-    :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
     :return: pandas dataframe of original source data
     """
     # extract data from zip file (only one csv)
-    with zipfile.ZipFile(io.BytesIO(response_load.content), "r") as f:
+    with zipfile.ZipFile(io.BytesIO(resp.content), "r") as f:
         # read in file names
         for name in f.namelist():
             data = f.open(name)
@@ -33,20 +30,20 @@ def fiws_call(url, response_load, args):
         return df
 
 
-def fiws_parse(dataframe_list, args):
+def fiws_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     # concat dataframes
-    df = pd.concat(dataframe_list, sort=False)
+    df = pd.concat(df_list, sort=False)
     # select data for chosen year, cast year as string to match argument
     df['Year'] = df['Year'].astype(str)
-    df = df[df['Year'] == args['year']].reset_index(drop=True)
+    df = df[df['Year'] == year].reset_index(drop=True)
     # add state fips codes, reading in datasets from common.py
     fips = get_all_state_FIPS_2().reset_index(drop=True)
     # ensure capitalization of state names

--- a/flowsa/data_source_scripts/USGS_MYB_Asbestos.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Asbestos.py
@@ -86,10 +86,10 @@ def usgs_asbestos_call(*, resp, year, **_):
     return df_data
 
 
-def usgs_asbestos_parse(*, dataframe_list, source, year, **_):
+def usgs_asbestos_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param source: source
     :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
@@ -102,7 +102,7 @@ def usgs_asbestos_parse(*, dataframe_list, source, year, **_):
     des = name
     dataframe = pd.DataFrame()
     col_name = usgs_myb_year(SPAN_YEARS, year)
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption:":

--- a/flowsa/data_source_scripts/USGS_MYB_Asbestos.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Asbestos.py
@@ -35,7 +35,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_asbestos_url_helper(build_url, config, args):
+def usgs_asbestos_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -53,17 +53,15 @@ def usgs_asbestos_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_asbestos_call(url, r, args):
+def usgs_asbestos_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
-    :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[4:11]).reindex()
     df_data = df_data.reset_index()
@@ -80,7 +78,7 @@ def usgs_asbestos_call(url, r, args):
                            "year_3", "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -88,22 +86,22 @@ def usgs_asbestos_call(url, r, args):
     return df_data
 
 
-def usgs_asbestos_parse(dataframe_list, args):
+def usgs_asbestos_parse(*, dataframe_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
     :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity"]
     product = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+    col_name = usgs_myb_year(SPAN_YEARS, year)
     for df in dataframe_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
@@ -115,13 +113,13 @@ def usgs_asbestos_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 elif str(df.iloc[index][col_name]) == "nan":
@@ -130,5 +128,5 @@ def usgs_asbestos_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(dataframe,
-                                                        str(args["year"]))
+                                                        str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Barite.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Barite.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_barite_url_helper(build_url, config, args):
+def usgs_barite_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,18 +51,18 @@ def usgs_barite_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_barite_call(url, r, args):
+def usgs_barite_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
     df_raw_data = pd.io.excel.read_excel(
-        io.BytesIO(r.content), sheet_name='T1')
+        io.BytesIO(resp.content), sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[7:14]).reindex()
     df_data = df_data.reset_index()
     del df_data["index"]
@@ -73,7 +73,7 @@ def usgs_barite_call(url, r, args):
                            "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -81,10 +81,10 @@ def usgs_barite_call(url, r, args):
     return df_data
 
 
-def usgs_barite_parse(dataframe_list, args):
+def usgs_barite_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -93,11 +93,11 @@ def usgs_barite_parse(dataframe_list, args):
     data = {}
     row_to_use = ["Quantity"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption:3":
@@ -110,13 +110,13 @@ def usgs_barite_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)":
                     data["FlowAmount"] = str(0)
@@ -124,5 +124,5 @@ def usgs_barite_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Beryllium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Beryllium.py
@@ -38,7 +38,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_beryllium_url_helper(build_url, config, args):
+def usgs_beryllium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -56,20 +56,20 @@ def usgs_beryllium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_beryllium_call(url, r, args):
+def usgs_beryllium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T4')
 
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
 
     df_data_1 = pd.DataFrame(df_raw_data_two.loc[6:9]).reindex()
@@ -94,7 +94,7 @@ def usgs_beryllium_call(url, r, args):
                              "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -108,10 +108,10 @@ def usgs_beryllium_call(url, r, args):
     return df_data
 
 
-def usgs_beryllium_parse(dataframe_list, args):
+def usgs_beryllium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -121,11 +121,11 @@ def usgs_beryllium_parse(dataframe_list, args):
     row_to_use = ["United States6", "Mine shipments1",
                   "Imports for consumption, beryl2"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
 
         for index, row in df.iterrows():
             prod = "production"
@@ -138,8 +138,8 @@ def usgs_beryllium_parse(dataframe_list, args):
                 product = df.iloc[index][
                     "Production"].strip().translate(remove_digits)
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
@@ -147,5 +147,5 @@ def usgs_beryllium_parse(dataframe_list, args):
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Boron.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Boron.py
@@ -35,7 +35,7 @@ from flowsa.common import WITHDRAWN_KEYWORD
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_boron_url_helper(build_url, config, args):
+def usgs_boron_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -53,17 +53,17 @@ def usgs_boron_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_boron_call(url, r, args):
+def usgs_boron_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data.loc[8:8]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -89,7 +89,7 @@ def usgs_boron_call(url, r, args):
                                  "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_one.columns:
         if col not in col_to_use:
             del df_data_one[col]
@@ -103,10 +103,10 @@ def usgs_boron_call(url, r, args):
     return df_data
 
 
-def usgs_boron_parse(dataframe_list, args):
+def usgs_boron_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -115,12 +115,12 @@ def usgs_boron_parse(dataframe_list, args):
     data = {}
     row_to_use = ["B2O3 content", "Quantity"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+    col_name = usgs_myb_year(SPAN_YEARS, year)
 
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
 
             if df.iloc[index]["Production"].strip() == "B2O3 content" or \
@@ -134,8 +134,8 @@ def usgs_boron_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 if des == name:
                     data['FlowName'] = name + " " + product
@@ -152,5 +152,5 @@ def usgs_boron_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Chromium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Chromium.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_chromium_url_helper(build_url, config, args):
+def usgs_chromium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,17 +51,17 @@ def usgs_chromium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_chromium_call(url, r, args):
+def usgs_chromium_call(*, resp, year, **_):
     """"
     Convert response for calling url to pandas dataframe,
     begin parsing df into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[4:24]).reindex()
     df_data = df_data.reset_index()
@@ -77,7 +77,7 @@ def usgs_chromium_call(url, r, args):
                            "space_4", "year_4", "space_5", "year_5", "space_6"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -85,10 +85,10 @@ def usgs_chromium_call(url, r, args):
     return df_data
 
 
-def usgs_chromium_parse(dataframe_list, args):
+def usgs_chromium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -97,11 +97,11 @@ def usgs_chromium_parse(dataframe_list, args):
     data = {}
     row_to_use = ["Secondary2", "Total"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Imports:":
                 product = "imports"
@@ -112,13 +112,13 @@ def usgs_chromium_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)":
                     data["FlowAmount"] = str(0)
@@ -126,5 +126,5 @@ def usgs_chromium_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Clay.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Clay.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2015-2016"
 
 
-def usgs_clay_url_helper(build_url, config, args):
+def usgs_clay_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,60 +51,60 @@ def usgs_clay_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_clay_call(url, r, args):
+def usgs_clay_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data_ball = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_ball = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                               sheet_name='T3')
     df_data_ball = pd.DataFrame(df_raw_data_ball.loc[19:19]).reindex()
     df_data_ball = df_data_ball.reset_index()
     del df_data_ball["index"]
 
-    df_raw_data_bentonite = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_bentonite = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                                    sheet_name='T4 ')
     df_data_bentonite = pd.DataFrame(
         df_raw_data_bentonite.loc[28:28]).reindex()
     df_data_bentonite = df_data_bentonite.reset_index()
     del df_data_bentonite["index"]
 
-    df_raw_data_common = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_common = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                                 sheet_name='T5 ')
     df_data_common = pd.DataFrame(df_raw_data_common.loc[40:40]).reindex()
     df_data_common = df_data_common.reset_index()
     del df_data_common["index"]
 
-    df_raw_data_fire = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_fire = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                               sheet_name='T6 ')
     df_data_fire = pd.DataFrame(df_raw_data_fire.loc[12:12]).reindex()
     df_data_fire = df_data_fire.reset_index()
     del df_data_fire["index"]
 
-    df_raw_data_fuller = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_fuller = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                                 sheet_name='T7 ')
     df_data_fuller = pd.DataFrame(df_raw_data_fuller.loc[17:17]).reindex()
     df_data_fuller = df_data_fuller.reset_index()
     del df_data_fuller["index"]
 
-    df_raw_data_kaolin = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_kaolin = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                                 sheet_name='T8 ')
     df_data_kaolin = pd.DataFrame(df_raw_data_kaolin.loc[18:18]).reindex()
     df_data_kaolin = df_data_kaolin.reset_index()
     del df_data_kaolin["index"]
 
-    df_raw_data_export = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_export = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                                 sheet_name='T13')
     df_data_export = pd.DataFrame(df_raw_data_export.loc[6:15]).reindex()
     df_data_export = df_data_export.reset_index()
     del df_data_export["index"]
 
-    df_raw_data_import = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_import = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                                 sheet_name='T14')
     df_data_import = pd.DataFrame(df_raw_data_import.loc[6:13]).reindex()
     df_data_import = df_data_import.reset_index()
@@ -145,7 +145,7 @@ def usgs_clay_call(url, r, args):
     df_data_import["type"] = "import"
 
     col_to_use = ["Production", "type"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_import.columns:
         if col not in col_to_use:
             del df_data_import[col]
@@ -168,10 +168,10 @@ def usgs_clay_call(url, r, args):
     return df_data
 
 
-def usgs_clay_parse(dataframe_list, args):
+def usgs_clay_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -184,7 +184,7 @@ def usgs_clay_parse(dataframe_list, args):
                   "Clays, not elsewhere classified",
                   "Clays, not elsewhere classified"]
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["type"].strip() == "import":
                 product = "imports"
@@ -195,8 +195,8 @@ def usgs_clay_parse(dataframe_list, args):
 
             if str(df.iloc[index]["Production"]).strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 if product == "production":
                     data['FlowName'] = \
@@ -210,7 +210,7 @@ def usgs_clay_parse(dataframe_list, args):
                     data["ActivityProducedBy"] = \
                         df.iloc[index]["Production"].strip()
 
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)" or \
                         str(df.iloc[index][col_name]) == "(2)":
@@ -219,5 +219,5 @@ def usgs_clay_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Cobalt.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Cobalt.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_cobalt_url_helper(build_url, config, args):
+def usgs_cobalt_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,19 +51,19 @@ def usgs_cobalt_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_cobalt_call(url, r, args):
+def usgs_cobalt_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T8')
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_1 = pd.DataFrame(df_raw_data_two.loc[6:11]).reindex()
     df_data_1 = df_data_1.reset_index()
@@ -88,7 +88,7 @@ def usgs_cobalt_call(url, r, args):
                              "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -102,22 +102,22 @@ def usgs_cobalt_call(url, r, args):
     return df_data
 
 
-def usgs_cobalt_parse(dataframe_list, args):
+def usgs_cobalt_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     row_to_use = ["United Statese, 16, 17", "Mine productione",
                   "Imports for consumption", "Exports"]
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
 
         for index, row in df.iterrows():
             prod = "production"
@@ -136,11 +136,11 @@ def usgs_cobalt_parse(dataframe_list, args):
                     "Production"].strip().translate(remove_digits)
                 data = usgs_myb_static_varaibles()
 
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
 
                 data["Unit"] = "Thousand Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
                 data['FlowName'] = name + " " + prod
@@ -150,5 +150,5 @@ def usgs_cobalt_parse(dataframe_list, args):
                 if data["FlowAmount"] not in remove_rows:
                     dataframe = dataframe.append(data, ignore_index=True)
                     dataframe = assign_fips_location_system(
-                        dataframe, str(args["year"]))
+                        dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Copper.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Copper.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2011-2015"
 
 
-def usgs_copper_url_helper(build_url, config, args):
+def usgs_copper_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -50,17 +50,15 @@ def usgs_copper_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_copper_call(url, r, args):
+def usgs_copper_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin
     parsing df into FBA format
-    :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data_1 = pd.DataFrame(df_raw_data.loc[12:12]).reindex()
     df_data_1 = df_data_1.reset_index()
@@ -79,7 +77,7 @@ def usgs_copper_call(url, r, args):
                              "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production", "Unit"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -93,27 +91,27 @@ def usgs_copper_call(url, r, args):
     return df_data
 
 
-def usgs_copper_parse(dataframe_list, args):
+def usgs_copper_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             remove_digits = str.maketrans('', '', digits)
             product = df.iloc[index][
                 "Production"].strip().translate(remove_digits)
             data = usgs_myb_static_varaibles()
-            data["SourceName"] = args["source"]
-            data["Year"] = str(args["year"])
+            data["SourceName"] = source
+            data["Year"] = str(year)
             if product == "Total":
                 prod = "production"
             elif product == "Exports, refined":
@@ -124,10 +122,10 @@ def usgs_copper_parse(dataframe_list, args):
             data["ActivityProducedBy"] = "Copper; Mine"
             data['FlowName'] = name + " " + prod
             data["Unit"] = "Metric Tons"
-            col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+            col_name = usgs_myb_year(SPAN_YEARS, year)
             data["Description"] = "Copper; Mine"
             data["FlowAmount"] = str(df.iloc[index][col_name])
             dataframe = dataframe.append(data, ignore_index=True)
             dataframe = assign_fips_location_system(
-                dataframe, str(args["year"]))
+                dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Diatomite.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Diatomite.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_diatomite_url_helper(build_url, config, args):
+def usgs_diatomite_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -50,18 +50,17 @@ def usgs_diatomite_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_diatomite_call(url, r, args):
+def usgs_diatomite_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
 
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[7:10]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -72,7 +71,7 @@ def usgs_diatomite_call(url, r, args):
                                "space_3", "year_3", "space_4", "year_4",
                                "space_5", "year_5"]
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -86,22 +85,22 @@ def usgs_diatomite_call(url, r, args):
     return df_data
 
 
-def usgs_diatomite_parse(dataframe_list, args):
+def usgs_diatomite_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", "Exports2", "Imports for consumption2"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports2":
                 prod = "exports"
@@ -115,11 +114,11 @@ def usgs_diatomite_parse(dataframe_list, args):
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
 
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
 
                 data["Unit"] = "Thousand metric tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["FlowAmount"] = str(df.iloc[index][col_name])
 
                 data["Description"] = name
@@ -127,5 +126,5 @@ def usgs_diatomite_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Feldspar.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Feldspar.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_feldspar_url_helper(build_url, config, args):
+def usgs_feldspar_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -50,17 +50,16 @@ def usgs_feldspar_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_feldspar_call(url, r, args):
+def usgs_feldspar_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin
     parsing df into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_two = pd.DataFrame(df_raw_data_two.loc[4:8]).reindex()
     df_data_two = df_data_two.reset_index()
@@ -80,7 +79,7 @@ def usgs_feldspar_call(url, r, args):
                                "year_3", "space_5", "year_4", "space_6",
                                "year_5"]
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_two.columns:
         if col not in col_to_use:
@@ -95,10 +94,10 @@ def usgs_feldspar_call(url, r, args):
     return df_data
 
 
-def usgs_feldspar_parse(dataframe_list, args):
+def usgs_feldspar_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -107,10 +106,10 @@ def usgs_feldspar_parse(dataframe_list, args):
     data = {}
     row_to_use = ["Quantity", "Quantity3"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports, feldspar:4":
                 prod = "exports"
@@ -127,10 +126,10 @@ def usgs_feldspar_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
@@ -140,5 +139,5 @@ def usgs_feldspar_parse(dataframe_list, args):
                     data['FlowName'] = name + " " + prod + " " + des
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Gallium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Gallium.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_gallium_url_helper(build_url, config, args):
+def usgs_gallium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -52,17 +52,17 @@ def usgs_gallium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_gallium_call(url, r, args):
+def usgs_gallium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[5:7]).reindex()
     df_data = df_data.reset_index()
@@ -79,7 +79,7 @@ def usgs_gallium_call(url, r, args):
                            "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -87,23 +87,23 @@ def usgs_gallium_call(url, r, args):
     return df_data
 
 
-def usgs_gallium_parse(dataframe_list, args):
+def usgs_gallium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Production, primary crude", "Metal"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption:":
@@ -114,13 +114,13 @@ def usgs_gallium_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Kilograms"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]).strip() == "--":
                     data["FlowAmount"] = str(0)
                 elif str(df.iloc[index][col_name]) == "nan":
@@ -129,5 +129,5 @@ def usgs_gallium_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Garnet.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Garnet.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_garnet_url_helper(build_url, config, args):
+def usgs_garnet_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -40,9 +40,6 @@ def usgs_garnet_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -50,17 +47,15 @@ def usgs_garnet_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_garnet_call(url, r, args):
+def usgs_garnet_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
-    :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_two = pd.DataFrame(df_raw_data_two.loc[4:5]).reindex()
     df_data_two = df_data_two.reset_index()
@@ -86,7 +81,7 @@ def usgs_garnet_call(url, r, args):
                                "year_3", "space_5", "year_4", "space_6",
                                "year_5"]
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_two.columns:
         if col not in col_to_use:
@@ -101,22 +96,22 @@ def usgs_garnet_call(url, r, args):
     return df_data
 
 
-def usgs_garnet_parse(dataframe_list, args):
+def usgs_garnet_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports:2":
                 prod = "exports"
@@ -128,15 +123,15 @@ def usgs_garnet_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Gold.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Gold.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_gold_url_helper(build_url, config, args):
+def usgs_gold_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,9 +42,6 @@ def usgs_gold_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,17 @@ def usgs_gold_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_gold_call(url, r, args):
+def usgs_gold_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[6:14]).reindex()
     df_data = df_data.reset_index()
@@ -74,7 +71,7 @@ def usgs_gold_call(url, r, args):
                            "year_3", "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -82,12 +79,12 @@ def usgs_gold_call(url, r, args):
     return df_data
 
 
-def usgs_gold_parse(dataframe_list, args):
+def usgs_gold_parse(*, df_list, source, year):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -96,9 +93,9 @@ def usgs_gold_parse(dataframe_list, args):
                   "Imports for consumption, refined bullion"]
     dataframe = pd.DataFrame()
     product = "production"
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
 
             if df.iloc[index]["Production"].strip() == "Quantity":
@@ -112,19 +109,19 @@ def usgs_gold_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "kilograms"
                 data['FlowName'] = name + " " + product
 
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 else:
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Gold.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Gold.py
@@ -79,7 +79,7 @@ def usgs_gold_call(*, resp, year, **_):
     return df_data
 
 
-def usgs_gold_parse(*, df_list, source, year):
+def usgs_gold_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
     :param df_list: list of dataframes to concat and format

--- a/flowsa/data_source_scripts/USGS_MYB_Graphite.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Graphite.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_graphite_url_helper(build_url, config, args):
+def usgs_graphite_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -52,17 +52,15 @@ def usgs_graphite_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_graphite_call(url, r, args):
+def usgs_graphite_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
-    :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[5:9]).reindex()
     df_data = df_data.reset_index()
@@ -74,7 +72,7 @@ def usgs_graphite_call(url, r, args):
                            "year_3", "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -82,23 +80,23 @@ def usgs_graphite_call(url, r, args):
     return df_data
 
 
-def usgs_graphite_parse(dataframe_list, args):
+def usgs_graphite_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantiy", "Quantity"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption:":
@@ -108,13 +106,13 @@ def usgs_graphite_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 elif str(df.iloc[index][col_name]) == "nan":
@@ -123,5 +121,5 @@ def usgs_graphite_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Gypsum.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Gypsum.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_gypsum_url_helper(build_url, config, args):
+def usgs_gypsum_url_helper(*, build_url, **_):
     """
      This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,17 +51,17 @@ def usgs_gypsum_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_gypsum_call(url, r, args):
+def usgs_gypsum_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin
     parsing df into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
 
     df_data_one = pd.DataFrame(df_raw_data_one.loc[7:10]).reindex()
@@ -78,7 +78,7 @@ def usgs_gypsum_call(url, r, args):
                                "year_2", "space_4", "year_3", "space_5",
                                "year_4", "space_6", "year_5"]
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -93,23 +93,23 @@ def usgs_gypsum_call(url, r, args):
     return df_data
 
 
-def usgs_gypsum_parse(dataframe_list, args):
+def usgs_gypsum_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", "Imports for consumption"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption":
@@ -120,8 +120,8 @@ def usgs_gypsum_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -131,5 +131,5 @@ def usgs_gypsum_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Iodine.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Iodine.py
@@ -33,7 +33,7 @@ from flowsa.common import WITHDRAWN_KEYWORD
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_iodine_url_helper(build_url, config, args):
+def usgs_iodine_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,17 +51,17 @@ def usgs_iodine_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_iodine_call(url, r, args):
+def usgs_iodine_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[6:10]).reindex()
     df_data = df_data.reset_index()
@@ -73,7 +73,7 @@ def usgs_iodine_call(url, r, args):
                            "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -81,23 +81,23 @@ def usgs_iodine_call(url, r, args):
     return df_data
 
 
-def usgs_iodine_parse(dataframe_list, args):
+def usgs_iodine_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Production", "Quantity, for consumption", "Exports2"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Imports:2":
                 product = "imports"
@@ -108,13 +108,13 @@ def usgs_iodine_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 elif str(df.iloc[index][col_name]) == "W":
@@ -123,5 +123,5 @@ def usgs_iodine_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_IronOre.py
+++ b/flowsa/data_source_scripts/USGS_MYB_IronOre.py
@@ -31,7 +31,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_iron_ore_url_helper(build_url, config, args):
+def usgs_iron_ore_url_helper(*, build_url, **_):
     """
      This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -39,9 +39,6 @@ def usgs_iron_ore_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -49,17 +46,15 @@ def usgs_iron_ore_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_iron_ore_call(url, r, args):
+def usgs_iron_ore_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
-    :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1 ')
     df_data = pd.DataFrame(df_raw_data.loc[7:25]).reindex()
     df_data = df_data.reset_index()
@@ -70,7 +65,7 @@ def usgs_iron_ore_call(url, r, args):
                            "space_2", "year_2", "space_3", "year_3",
                            "space_4", "year_4", "space_5", "year_5"]
     col_to_use = ["Production", "Units"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -78,21 +73,21 @@ def usgs_iron_ore_call(url, r, args):
     return df_data
 
 
-def usgs_iron_ore_parse(dataframe_list, args):
+def usgs_iron_ore_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     row_to_use = ["Gross weight", "Quantity"]
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
 
             if df.iloc[index]["Production"].strip() == "Production:":
@@ -105,18 +100,18 @@ def usgs_iron_ore_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data['FlowName'] = "Iron Ore " + product
                 data["Description"] = "Iron Ore"
                 data["ActivityProducedBy"] = "Iron Ore"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 else:
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Kyanite.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Kyanite.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_kyanite_url_helper(build_url, config, args):
+def usgs_kyanite_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_kyanite_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -51,17 +48,16 @@ def usgs_kyanite_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_kyanite_call(url, r, args):
+def usgs_kyanite_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[4:13]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -73,7 +69,7 @@ def usgs_kyanite_call(url, r, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -87,10 +83,10 @@ def usgs_kyanite_call(url, r, args):
     return df_data
 
 
-def usgs_kyanite_parse(dataframe_list, args):
+def usgs_kyanite_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -99,11 +95,11 @@ def usgs_kyanite_parse(dataframe_list, args):
     data = {}
     row_to_use = ["Quantity", "Quantity2"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Exports of kyanite concentrate:3":
@@ -116,8 +112,8 @@ def usgs_kyanite_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -127,5 +123,5 @@ def usgs_kyanite_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Lead.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Lead.py
@@ -22,7 +22,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2012-2016"
 
 
-def usgs_lead_url_helper(build_url, config, args):
+def usgs_lead_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -30,9 +30,6 @@ def usgs_lead_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -40,17 +37,16 @@ def usgs_lead_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_lead_call(url, r, args):
+def usgs_lead_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[8:15]).reindex()
     df_data = df_data.reset_index()
@@ -67,7 +63,7 @@ def usgs_lead_call(url, r, args):
                            "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production", "Units"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -75,17 +71,17 @@ def usgs_lead_call(url, r, args):
     return df_data
 
 
-def usgs_lead_parse(dataframe_list, args):
+def usgs_lead_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     row_to_use = ["Primary lead, refined content, "
                   "domestic ores and base bullion",
@@ -95,7 +91,7 @@ def usgs_lead_parse(dataframe_list, args):
                      "Imports for consumption, lead content:"]
     dataframe = pd.DataFrame()
     product = "production"
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() in import_export:
                 if df.iloc[index]["Production"].strip() == \
@@ -106,18 +102,18 @@ def usgs_lead_parse(dataframe_list, args):
                     product = "imports"
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product + \
                                    " " + df.iloc[index]["Production"]
                 data["ActivityProducedBy"] = df.iloc[index]["Production"]
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 else:
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Lime.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Lime.py
@@ -35,7 +35,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_lime_url_helper(build_url, config, args):
+def usgs_lime_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -43,9 +43,6 @@ def usgs_lime_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -53,18 +50,17 @@ def usgs_lime_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_lime_call(url, r, args):
+def usgs_lime_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
 
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
 
     df_data_1 = pd.DataFrame(df_raw_data_two.loc[16:16]).reindex()
@@ -90,7 +86,7 @@ def usgs_lime_call(url, r, args):
                              "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -104,22 +100,22 @@ def usgs_lime_call(url, r, args):
     return df_data
 
 
-def usgs_lime_parse(dataframe_list, args):
+def usgs_lime_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Total", "Quantity"]
     import_export = ["Exports:7", "Imports for consumption:7"]
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         prod = "production"
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports:7":
@@ -132,10 +128,10 @@ def usgs_lime_parse(dataframe_list, args):
                 product = df.iloc[index][
                     "Production"].strip().translate(remove_digits)
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
                 if product.strip() == "Total":
@@ -146,5 +142,5 @@ def usgs_lime_parse(dataframe_list, args):
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Lithium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Lithium.py
@@ -33,7 +33,7 @@ from flowsa.common import WITHDRAWN_KEYWORD
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_lithium_url_helper(build_url, config, args):
+def usgs_lithium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,17 +51,16 @@ def usgs_lithium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_lithium_call(url, r, args):
+def usgs_lithium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[6:8]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -78,7 +77,7 @@ def usgs_lithium_call(url, r, args):
                                "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -92,23 +91,23 @@ def usgs_lithium_call(url, r, args):
     return df_data
 
 
-def usgs_lithium_parse(dataframe_list, args):
+def usgs_lithium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Exports3", "Imports3", "Production"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports3":
                 prod = "exports"
@@ -119,8 +118,8 @@ def usgs_lithium_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -130,5 +129,5 @@ def usgs_lithium_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Magnesium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Magnesium.py
@@ -30,7 +30,7 @@ from flowsa.common import WITHDRAWN_KEYWORD
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_magnesium_url_helper(build_url, config, args):
+def usgs_magnesium_url_helper(*, build_url, **_):
     """
      This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -38,9 +38,6 @@ def usgs_magnesium_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -48,17 +45,16 @@ def usgs_magnesium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_magnesium_call(url, r, args):
+def usgs_magnesium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[7:15]).reindex()
     df_data = df_data.reset_index()
@@ -70,7 +66,7 @@ def usgs_magnesium_call(url, r, args):
                            "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -78,21 +74,21 @@ def usgs_magnesium_call(url, r, args):
     return df_data
 
 
-def usgs_magnesium_parse(dataframe_list, args):
+def usgs_magnesium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Secondary", "Primary", "Exports", "Imports for consumption"]
     dataframe = pd.DataFrame()
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports":
                 product = "exports"
@@ -105,13 +101,13 @@ def usgs_magnesium_parse(dataframe_list, args):
                           df.iloc[index]["Production"].strip()
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 elif str(df.iloc[index][col_name]) == "W":
@@ -120,5 +116,5 @@ def usgs_magnesium_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Manganese.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Manganese.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2012-2016"
 
 
-def usgs_manganese_url_helper(build_url, config, args):
+def usgs_manganese_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -40,9 +40,6 @@ def usgs_manganese_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -50,17 +47,15 @@ def usgs_manganese_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_manganese_call(url, r, args):
+def usgs_manganese_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
-    :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[7:9]).reindex()
     df_data = df_data.reset_index()
@@ -76,7 +71,7 @@ def usgs_manganese_call(url, r, args):
                            "year_3", "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -84,23 +79,23 @@ def usgs_manganese_call(url, r, args):
     return df_data
 
 
-def usgs_manganese_parse(dataframe_list, args):
+def usgs_manganese_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Production", "Exports", "Imports for consumption"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption":
@@ -111,13 +106,13 @@ def usgs_manganese_parse(dataframe_list, args):
                 product = "exports"
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)":
                     data["FlowAmount"] = str(0)
@@ -125,5 +120,5 @@ def usgs_manganese_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_ManufacturedAbrasive.py
+++ b/flowsa/data_source_scripts/USGS_MYB_ManufacturedAbrasive.py
@@ -35,7 +35,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2017-2018"
 
 
-def usgs_ma_url_helper(build_url, config, args):
+def usgs_ma_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -53,17 +53,17 @@ def usgs_ma_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_ma_call(url, r, args):
+def usgs_ma_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T2')
     df_data = pd.DataFrame(df_raw_data.loc[6:7]).reindex()
     df_data = df_data.reset_index()
@@ -84,7 +84,7 @@ def usgs_ma_call(url, r, args):
                            "quality_year_2", "space_4", "value_year_2"]
 
     col_to_use = ["Product"]
-    col_to_use.append("quality_" + usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append("quality_" + usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -92,10 +92,10 @@ def usgs_ma_call(url, r, args):
     return df_data
 
 
-def usgs_ma_parse(dataframe_list, args):
+def usgs_ma_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -103,26 +103,26 @@ def usgs_ma_parse(dataframe_list, args):
     """
     data = {}
     row_to_use = ["Silicon carbide"]
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             remove_digits = str.maketrans('', '', digits)
             product = df.iloc[index][
                 "Product"].strip().translate(remove_digits)
             if product in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data['FlowName'] = "Silicon carbide"
                 data["ActivityProducedBy"] = "Silicon carbide"
                 data["Unit"] = "Metric Tons"
-                col_name = "quality_" + usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = "quality_" + usgs_myb_year(SPAN_YEARS, year)
                 col_name_array = col_name.split("_")
                 data["Description"] = product + " " + col_name_array[0]
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Mica.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Mica.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_mica_url_helper(build_url, config, args):
+def usgs_mica_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,22 +51,21 @@ def usgs_mica_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_mica_call(url, r, args):
+def usgs_mica_call(*, resp, source, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[4:6]).reindex()
     df_data_one = df_data_one.reset_index()
     del df_data_one["index"]
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     if len(df_data_one. columns) == 12:
         df_data_one.columns = ["Production", "Unit", "space_2",  "year_1",
@@ -74,7 +73,7 @@ def usgs_mica_call(url, r, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_one.columns:
         if col not in col_to_use:
             del df_data_one[col]
@@ -86,23 +85,23 @@ def usgs_mica_call(url, r, args):
     return df_data
 
 
-def usgs_mica_parse(dataframe_list, args):
+def usgs_mica_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Production, sold or used by producers:":
@@ -110,8 +109,8 @@ def usgs_mica_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -121,5 +120,5 @@ def usgs_mica_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Molybdenum.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Molybdenum.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_molybdenum_url_helper(build_url, config, args):
+def usgs_molybdenum_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,9 +42,6 @@ def usgs_molybdenum_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,16 @@ def usgs_molybdenum_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_molybdenum_call(url, r, args):
+def usgs_molybdenum_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[7:11]).reindex()
     df_data = df_data.reset_index()
@@ -74,7 +70,7 @@ def usgs_molybdenum_call(url, r, args):
                            "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -82,22 +78,22 @@ def usgs_molybdenum_call(url, r, args):
     return df_data
 
 
-def usgs_molybdenum_parse(dataframe_list, args):
+def usgs_molybdenum_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Production", "Imports for consumption", "Exports"]
     dataframe = pd.DataFrame()
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
 
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
 
             if df.iloc[index]["Production"].strip() == "Exports":
@@ -109,18 +105,18 @@ def usgs_molybdenum_parse(dataframe_list, args):
                 product = "production"
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 else:
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Nickel.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Nickel.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2012-2016"
 
 
-def usgs_nickel_url_helper(build_url, config, args):
+def usgs_nickel_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -51,23 +51,22 @@ def usgs_nickel_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_nickel_call(url, r, args):
+def usgs_nickel_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T10')
     df_data_1 = pd.DataFrame(df_raw_data.loc[36:36]).reindex()
     df_data_1 = df_data_1.reset_index()
     del df_data_1["index"]
 
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_2 = pd.DataFrame(df_raw_data_two.loc[11:16]).reindex()
     df_data_2 = df_data_2.reset_index()
@@ -89,7 +88,7 @@ def usgs_nickel_call(url, r, args):
                              "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -103,12 +102,12 @@ def usgs_nickel_call(url, r, args):
     return df_data
 
 
-def usgs_nickel_parse(dataframe_list, args):
+def usgs_nickel_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -116,10 +115,10 @@ def usgs_nickel_parse(dataframe_list, args):
     row_to_use = ["Ores and concentrates3",
                   "United States, sulfide ore, concentrate"]
     import_export = ["Exports:", "Imports for consumption:"]
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         prod = "production"
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports:":
@@ -132,10 +131,10 @@ def usgs_nickel_parse(dataframe_list, args):
                 product = df.iloc[index][
                     "Production"].strip().translate(remove_digits)
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if product.strip() == \
                         "United States, sulfide ore, concentrate":
                     data["Description"] = \
@@ -153,5 +152,5 @@ def usgs_nickel_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Peat.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Peat.py
@@ -30,7 +30,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_peat_url_helper(build_url, config, args):
+def usgs_peat_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -38,9 +38,6 @@ def usgs_peat_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -48,20 +45,18 @@ def usgs_peat_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_peat_call(url, response_load, args):
+def usgs_peat_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
     :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
 
-    r = response_load
     """Calls the excel sheet for nickel and removes extra columns"""
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[7:18]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -78,7 +73,7 @@ def usgs_peat_call(url, response_load, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -92,23 +87,23 @@ def usgs_peat_call(url, response_load, args):
     return df_data
 
 
-def usgs_peat_parse(dataframe_list, args):
+def usgs_peat_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Production", "Exports", "Imports for consumption"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Production":
                 prod = "production"
@@ -120,8 +115,8 @@ def usgs_peat_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -131,5 +126,5 @@ def usgs_peat_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Perlite.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Perlite.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_perlite_url_helper(build_url, config, args):
+def usgs_perlite_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_perlite_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -51,17 +48,15 @@ def usgs_perlite_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_perlite_call(url, r, args):
+def usgs_perlite_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
-    :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[6:6]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -80,7 +75,7 @@ def usgs_perlite_call(url, r, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -95,23 +90,23 @@ def usgs_perlite_call(url, r, args):
     return df_data
 
 
-def usgs_perlite_parse(dataframe_list, args):
+def usgs_perlite_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", "Mine production2"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Mine production2":
                 prod = "production"
@@ -123,8 +118,8 @@ def usgs_perlite_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -134,5 +129,5 @@ def usgs_perlite_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Phosphate.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Phosphate.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_phosphate_url_helper(build_url, config, args):
+def usgs_phosphate_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,9 +42,6 @@ def usgs_phosphate_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -53,18 +50,17 @@ def usgs_phosphate_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_phosphate_call(url, r, args):
+def usgs_phosphate_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
 
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[7:9]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -89,7 +85,7 @@ def usgs_phosphate_call(url, r, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -104,23 +100,23 @@ def usgs_phosphate_call(url, r, args):
     return df_data
 
 
-def usgs_phosphate_parse(dataframe_list, args):
+def usgs_phosphate_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Gross weight", "Quantity, gross weight"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Marketable production:":
@@ -132,8 +128,8 @@ def usgs_phosphate_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -143,5 +139,5 @@ def usgs_phosphate_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Potash.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Potash.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_potash_url_helper(build_url, config, args):
+def usgs_potash_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_potash_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -51,17 +48,16 @@ def usgs_potash_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_potash_call(url, r, args):
+def usgs_potash_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[6:8]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -86,7 +82,7 @@ def usgs_potash_call(url, r, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -101,23 +97,23 @@ def usgs_potash_call(url, r, args):
     return df_data
 
 
-def usgs_potash_parse(dataframe_list, args):
+def usgs_potash_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["K2O equivalent"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Production:3":
                 prod = "production"
@@ -129,8 +125,8 @@ def usgs_potash_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -140,5 +136,5 @@ def usgs_potash_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Pumice.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Pumice.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_pumice_url_helper(build_url, config, args):
+def usgs_pumice_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_pumice_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -51,17 +48,16 @@ def usgs_pumice_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_pumice_call(url, r, args):
+def usgs_pumice_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[6:11]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -79,7 +75,7 @@ def usgs_pumice_call(url, r, args):
                                "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -93,23 +89,23 @@ def usgs_pumice_call(url, r, args):
     return df_data
 
 
-def usgs_pumice_parse(dataframe_list, args):
+def usgs_pumice_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", "Imports for consumption3", "Exports3"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Quantity":
                 prod = "production"
@@ -121,8 +117,8 @@ def usgs_pumice_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -132,5 +128,5 @@ def usgs_pumice_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Rhenium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Rhenium.py
@@ -35,7 +35,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_rhenium_url_helper(build_url, config, args):
+def usgs_rhenium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -43,9 +43,6 @@ def usgs_rhenium_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -54,17 +51,16 @@ def usgs_rhenium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_rhenium_call(url, r, args):
+def usgs_rhenium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[5:13]).reindex()
     df_data = df_data.reset_index()
@@ -86,19 +82,19 @@ def usgs_rhenium_call(url, r, args):
                            "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
     return df_data
 
 
-def usgs_rhenium_parse(dataframe_list, args):
+def usgs_rhenium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -106,9 +102,9 @@ def usgs_rhenium_parse(dataframe_list, args):
     row_to_use = ["Total, rhenium content",
                   "Production, mine, rhenium content2"]
     dataframe = pd.DataFrame()
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Total, rhenium content":
@@ -118,18 +114,18 @@ def usgs_rhenium_parse(dataframe_list, args):
                 product = "production"
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "kilograms"
                 data['FlowName'] = name + " " + product
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 else:
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Salt.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Salt.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_salt_url_helper(build_url, config, args):
+def usgs_salt_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_salt_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,16 @@ def usgs_salt_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_salt_call(url, r, args):
+def usgs_salt_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[6:11]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -87,7 +83,7 @@ def usgs_salt_call(url, r, args):
                                "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -102,23 +98,23 @@ def usgs_salt_call(url, r, args):
     return df_data
 
 
-def usgs_salt_parse(dataframe_list, args):
+def usgs_salt_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", "Total"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Production:2":
                 prod = "production"
@@ -130,8 +126,8 @@ def usgs_salt_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -141,5 +137,5 @@ def usgs_salt_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_SandGravelConstruction.py
+++ b/flowsa/data_source_scripts/USGS_MYB_SandGravelConstruction.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_sgc_url_helper(build_url, config, args):
+def usgs_sgc_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_sgc_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,16 @@ def usgs_sgc_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_sgc_call(url, r, args):
+def usgs_sgc_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
 
     df_data_1 = pd.DataFrame(df_raw_data_two.loc[5:12]).reindex()
@@ -75,7 +71,7 @@ def usgs_sgc_call(url, r, args):
                              "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -83,19 +79,19 @@ def usgs_sgc_call(url, r, args):
     return df_data_1
 
 
-def usgs_sgc_parse(dataframe_list, args):
+def usgs_sgc_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity"]
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
 
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
@@ -110,10 +106,10 @@ def usgs_sgc_parse(dataframe_list, args):
                 remove_digits = str.maketrans('', '', digits)
                 product = df.iloc[index][
                     "Production"].strip().translate(remove_digits)
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["Description"] = "Sand Gravel Construction"
                 data["ActivityProducedBy"] = "Sand Gravel Construction"
                 if product.strip() == "Quantity":
@@ -121,5 +117,5 @@ def usgs_sgc_parse(dataframe_list, args):
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_SandGravelIndustrial.py
+++ b/flowsa/data_source_scripts/USGS_MYB_SandGravelIndustrial.py
@@ -33,7 +33,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_sgi_url_helper(build_url, config, args):
+def usgs_sgi_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_sgi_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -51,18 +48,17 @@ def usgs_sgi_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_sgi_call(url, r, args):
+def usgs_sgi_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
 
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
 
     df_data_1 = pd.DataFrame(df_raw_data_two.loc[6:10]).reindex()
@@ -88,7 +84,7 @@ def usgs_sgi_call(url, r, args):
                              "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -102,19 +98,19 @@ def usgs_sgi_call(url, r, args):
     return df_data
 
 
-def usgs_sgi_parse(dataframe_list, args):
+def usgs_sgi_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", "Total"]
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
 
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Sold or used:":
@@ -129,15 +125,15 @@ def usgs_sgi_parse(dataframe_list, args):
                 product = df.iloc[index][
                     "Production"].strip().translate(remove_digits)
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["Description"] = "Sand Gravel Industrial"
                 data["ActivityProducedBy"] = "Sand Gravel Industrial"
                 data['FlowName'] = "Sand Gravel Industrial " + prod
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Silver.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Silver.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2012-2016"
 
 
-def usgs_silver_url_helper(build_url, config, args):
+def usgs_silver_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,9 +42,6 @@ def usgs_silver_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,16 @@ def usgs_silver_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_silver_call(url, r, args):
+def usgs_silver_call(*, resp, year, **_):
     """
      Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[4:14]).reindex()
     df_data = df_data.reset_index()
@@ -74,28 +70,28 @@ def usgs_silver_call(url, r, args):
                            "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
     return df_data
 
 
-def usgs_silver_parse(dataframe_list, args):
+def usgs_silver_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Ore and concentrate", "Ore and concentrate2", "Quantity"]
     dataframe = pd.DataFrame()
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Ore and concentrate2":
                 product = "imports"
@@ -105,13 +101,13 @@ def usgs_silver_parse(dataframe_list, args):
                 product = "exports"
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)":
                     data["FlowAmount"] = str(0)
@@ -119,5 +115,5 @@ def usgs_silver_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_StoneCrushed.py
+++ b/flowsa/data_source_scripts/USGS_MYB_StoneCrushed.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_stonecr_url_helper(build_url, config, args):
+def usgs_stonecr_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,9 +42,6 @@ def usgs_stonecr_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,16 @@ def usgs_stonecr_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_stonecr_call(url, r, args):
+def usgs_stonecr_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
 
     df_data_1 = pd.DataFrame(df_raw_data_two.loc[5:15]).reindex()
@@ -80,7 +76,7 @@ def usgs_stonecr_call(url, r, args):
                              "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -88,19 +84,19 @@ def usgs_stonecr_call(url, r, args):
     return df_data_1
 
 
-def usgs_stonecr_parse(dataframe_list, args):
+def usgs_stonecr_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity"]
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Sold or used by producers:2":
@@ -117,10 +113,10 @@ def usgs_stonecr_parse(dataframe_list, args):
                 product = df.iloc[index][
                     "Production"].strip().translate(remove_digits)
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["Description"] = "Stone Crushed"
                 data["ActivityProducedBy"] = "Stone Crushed"
                 data['FlowName'] = "Stone Crushed " + prod
@@ -128,5 +124,5 @@ def usgs_stonecr_parse(dataframe_list, args):
                 if prod != "recycle":
                     dataframe = dataframe.append(data, ignore_index=True)
                     dataframe = assign_fips_location_system(
-                        dataframe, str(args["year"]))
+                        dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_StoneDimension.py
+++ b/flowsa/data_source_scripts/USGS_MYB_StoneDimension.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_stonedis_url_helper(build_url, config, args):
+def usgs_stonedis_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -40,9 +40,6 @@ def usgs_stonedis_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -51,18 +48,17 @@ def usgs_stonedis_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_stonedis_call(url, r, args):
+def usgs_stonedis_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
 
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
 
     df_data_1 = pd.DataFrame(df_raw_data_two.loc[6:9]).reindex()
@@ -75,7 +71,7 @@ def usgs_stonedis_call(url, r, args):
                              "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_1.columns:
         if col not in col_to_use:
             del df_data_1[col]
@@ -83,19 +79,19 @@ def usgs_stonedis_call(url, r, args):
     return df_data_1
 
 
-def usgs_stonedis_parse(dataframe_list, args):
+def usgs_stonedis_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", ]
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Quantity":
                 prod = "production"
@@ -109,10 +105,10 @@ def usgs_stonedis_parse(dataframe_list, args):
                 product = df.iloc[index][
                     "Production"].strip().translate(remove_digits)
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["Description"] = "Stone Dimension"
                 data["ActivityProducedBy"] = "Stone Dimension"
                 data['FlowName'] = "Stone Dimension " + prod
@@ -120,5 +116,5 @@ def usgs_stonedis_parse(dataframe_list, args):
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Strontium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Strontium.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_strontium_url_helper(build_url, config, args):
+def usgs_strontium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -40,9 +40,6 @@ def usgs_strontium_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -50,17 +47,16 @@ def usgs_strontium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_strontium_call(url, r, args):
+def usgs_strontium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[6:13]).reindex()
     df_data = df_data.reset_index()
@@ -77,7 +73,7 @@ def usgs_strontium_call(url, r, args):
                            "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -85,12 +81,12 @@ def usgs_strontium_call(url, r, args):
     return df_data
 
 
-def usgs_strontium_parse(dataframe_list, args):
+def usgs_strontium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -98,11 +94,11 @@ def usgs_strontium_parse(dataframe_list, args):
     row_to_use = ["Production, strontium minerals", "Strontium compounds3",
                   "Celestite4", "Strontium carbonate"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption:2":
@@ -115,8 +111,8 @@ def usgs_strontium_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 if usgs_myb_remove_digits(
                         df.iloc[index]["Production"].strip()) == "Celestite":
@@ -128,7 +124,7 @@ def usgs_strontium_parse(dataframe_list, args):
                 data["Description"] = usgs_myb_remove_digits(
                     df.iloc[index]["Production"].strip())
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)":
                     data["FlowAmount"] = str(0)
@@ -136,5 +132,5 @@ def usgs_strontium_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Talc.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Talc.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_talc_url_helper(build_url, config, args):
+def usgs_talc_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -40,9 +40,6 @@ def usgs_talc_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -50,17 +47,16 @@ def usgs_talc_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_talc_call(url, r, args):
+def usgs_talc_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[6:8]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -79,7 +75,7 @@ def usgs_talc_call(url, r, args):
                                "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -94,23 +90,23 @@ def usgs_talc_call(url, r, args):
     return df_data
 
 
-def usgs_talc_parse(dataframe_list, args):
+def usgs_talc_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Quantity", "Talc"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Mine production, crude:":
@@ -123,8 +119,8 @@ def usgs_talc_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -134,5 +130,5 @@ def usgs_talc_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Titanium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Titanium.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_titanium_url_helper(build_url, config, args):
+def usgs_titanium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -50,17 +50,17 @@ def usgs_titanium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_titanium_call(url, r, args):
+def usgs_titanium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
+    :param resp: df, response from url call
     :param args: dictionary, arguments specified when running
         flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data_1 = pd.DataFrame(df_raw_data.loc[4:7]).reindex()
     df_data_1 = df_data_1.reset_index()
@@ -81,7 +81,7 @@ def usgs_titanium_call(url, r, args):
                              "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_2.columns:
         if col not in col_to_use:
             del df_data_2[col]
@@ -94,10 +94,10 @@ def usgs_titanium_call(url, r, args):
     return df_data
 
 
-def usgs_titanium_parse(dataframe_list, args):
+def usgs_titanium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -108,7 +108,7 @@ def usgs_titanium_parse(dataframe_list, args):
     dataframe = pd.DataFrame()
     name = ""
 
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption":
@@ -124,13 +124,13 @@ def usgs_titanium_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)":
                     data["FlowAmount"] = str(0)
@@ -138,5 +138,5 @@ def usgs_titanium_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Tungsten.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Tungsten.py
@@ -33,7 +33,7 @@ from flowsa.common import WITHDRAWN_KEYWORD
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_tungsten_url_helper(build_url, config, args):
+def usgs_tungsten_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -41,9 +41,6 @@ def usgs_tungsten_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -51,17 +48,16 @@ def usgs_tungsten_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_tungsten_call(url, r, args):
+def usgs_tungsten_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data = pd.DataFrame(df_raw_data.loc[7:10]).reindex()
     df_data = df_data.reset_index()
@@ -73,7 +69,7 @@ def usgs_tungsten_call(url, r, args):
                            "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data.columns:
         if col not in col_to_use:
             del df_data[col]
@@ -81,23 +77,23 @@ def usgs_tungsten_call(url, r, args):
     return df_data
 
 
-def usgs_tungsten_parse(dataframe_list, args):
+def usgs_tungsten_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Production", "Exports", "Imports for consumption"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption":
@@ -109,13 +105,13 @@ def usgs_tungsten_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = name
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--":
                     data["FlowAmount"] = str(0)
                 elif str(df.iloc[index][col_name]) == "nan":
@@ -124,5 +120,5 @@ def usgs_tungsten_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Vermiculite.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Vermiculite.py
@@ -32,7 +32,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_vermiculite_url_helper(build_url, config, args):
+def usgs_vermiculite_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -40,9 +40,6 @@ def usgs_vermiculite_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -50,17 +47,16 @@ def usgs_vermiculite_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_vermiculite_call(url, r, args):
+def usgs_vermiculite_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[6:12]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -72,7 +68,7 @@ def usgs_vermiculite_call(url, r, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -86,10 +82,10 @@ def usgs_vermiculite_call(url, r, args):
     return df_data
 
 
-def usgs_vermiculite_parse(dataframe_list, args):
+def usgs_vermiculite_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
+    :param df_list: list of dataframes to concat and format
     :param args: dictionary, used to run flowbyactivity.py
         ('year' and 'source')
     :return: df, parsed and partially formatted to flowbyactivity
@@ -99,11 +95,11 @@ def usgs_vermiculite_parse(dataframe_list, args):
     row_to_use = ["Production, concentratee, 2, 3", "Exportse, 4",
                   "Imports for consumptione, 4"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Production, concentratee, 2, 3":
@@ -116,8 +112,8 @@ def usgs_vermiculite_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Thousand Metric Tons"
                 data["FlowAmount"] = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -127,5 +123,5 @@ def usgs_vermiculite_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Zeolites.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Zeolites.py
@@ -34,7 +34,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2014-2018"
 
 
-def usgs_zeolites_url_helper(build_url, config, args):
+def usgs_zeolites_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,9 +42,6 @@ def usgs_zeolites_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,16 @@ def usgs_zeolites_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_zeolites_call(url, r, args):
+def usgs_zeolites_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[4:7]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -74,7 +70,7 @@ def usgs_zeolites_call(url, r, args):
                                "space_5", "year_4", "space_6", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_one.columns:
         if col not in col_to_use:
@@ -88,23 +84,23 @@ def usgs_zeolites_call(url, r, args):
     return df_data
 
 
-def usgs_zeolites_parse(dataframe_list, args):
+def usgs_zeolites_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     data = {}
     row_to_use = ["Production", "Exportse", "Importse"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     des = name
     dataframe = pd.DataFrame()
-    col_name = usgs_myb_year(SPAN_YEARS, args["year"])
-    for df in dataframe_list:
+    col_name = usgs_myb_year(SPAN_YEARS, year)
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Production":
                 prod = "production"
@@ -116,8 +112,8 @@ def usgs_zeolites_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 flow_amount = str(df.iloc[index][col_name])
                 if str(df.iloc[index][col_name]) == "W":
@@ -130,5 +126,5 @@ def usgs_zeolites_parse(dataframe_list, args):
                 data['FlowName'] = name + " " + prod
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Zinc.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Zinc.py
@@ -31,7 +31,7 @@ from flowsa.data_source_scripts.USGS_MYB_Common import *
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_zinc_url_helper(build_url, config, args):
+def usgs_zinc_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -39,9 +39,6 @@ def usgs_zinc_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -49,23 +46,22 @@ def usgs_zinc_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_zinc_call(url, r, args):
+def usgs_zinc_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_two = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T1')
     df_data_two = pd.DataFrame(df_raw_data_two.loc[9:20]).reindex()
     df_data_two = df_data_two.reset_index()
     del df_data_two["index"]
 
-    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data_one = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                              sheet_name='T9')
     df_data_one = pd.DataFrame(df_raw_data_one.loc[53:53]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -86,7 +82,7 @@ def usgs_zinc_call(url, r, args):
                                "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
 
     for col in df_data_two.columns:
         if col not in col_to_use:
@@ -104,12 +100,12 @@ def usgs_zinc_call(url, r, args):
     return df_data
 
 
-def usgs_zinc_parse(dataframe_list, args):
+def usgs_zinc_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -119,9 +115,9 @@ def usgs_zinc_parse(dataframe_list, args):
     import_export = ["Exports:", "Imports for consumption:",
                      "Recoverable zinc:"]
     prod = ""
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == "Exports:":
                 prod = "exports"
@@ -136,10 +132,10 @@ def usgs_zinc_parse(dataframe_list, args):
             if df.iloc[index]["Production"].strip() in row_to_use:
                 product = df.iloc[index]["Production"].strip()
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 data["FlowAmount"] = str(df.iloc[index][col_name])
 
                 if product.strip() == "Quantity":
@@ -159,5 +155,5 @@ def usgs_zinc_parse(dataframe_list, args):
 
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_MYB_Zirconium.py
+++ b/flowsa/data_source_scripts/USGS_MYB_Zirconium.py
@@ -34,7 +34,7 @@ from flowsa.common import WITHDRAWN_KEYWORD
 SPAN_YEARS = "2013-2017"
 
 
-def usgs_zirconium_url_helper(build_url, config, args):
+def usgs_zirconium_url_helper(*, build_url, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,9 +42,6 @@ def usgs_zirconium_url_helper(build_url, config, args):
     does not parse the data, only modifies the urls from which data is
     obtained.
     :param build_url: string, base url
-    :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -52,17 +49,16 @@ def usgs_zirconium_url_helper(build_url, config, args):
     return [url]
 
 
-def usgs_zirconium_call(url, r, args):
+def usgs_zirconium_call(*, resp, year, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
     :param url: string, url
-    :param r: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
+    :param resp: df, response from url call
+    :param year: year
     :return: pandas dataframe of original source data
     """
-    df_raw_data = pd.io.excel.read_excel(io.BytesIO(r.content),
+    df_raw_data = pd.io.excel.read_excel(io.BytesIO(resp.content),
                                          sheet_name='T1')
     df_data_one = pd.DataFrame(df_raw_data.loc[6:10]).reindex()
     df_data_one = df_data_one.reset_index()
@@ -87,7 +83,7 @@ def usgs_zirconium_call(url, r, args):
                                "space_4", "year_4", "space_5", "year_5"]
 
     col_to_use = ["Production"]
-    col_to_use.append(usgs_myb_year(SPAN_YEARS, args["year"]))
+    col_to_use.append(usgs_myb_year(SPAN_YEARS, year))
     for col in df_data_one.columns:
         if col not in col_to_use:
             del df_data_one[col]
@@ -100,12 +96,12 @@ def usgs_zirconium_call(url, r, args):
     return df_data
 
 
-def usgs_zirconium_parse(dataframe_list, args):
+def usgs_zirconium_parse(*, df_list, source, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param source: source
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -114,9 +110,9 @@ def usgs_zirconium_parse(dataframe_list, args):
                   "Hafnium, unwrought, including powder, "
                   "imports for consumption"]
     dataframe = pd.DataFrame()
-    name = usgs_myb_name(args["source"])
+    name = usgs_myb_name(source)
 
-    for df in dataframe_list:
+    for df in df_list:
         for index, row in df.iterrows():
             if df.iloc[index]["Production"].strip() == \
                     "Imports for consumption3":
@@ -136,13 +132,13 @@ def usgs_zirconium_parse(dataframe_list, args):
 
             if df.iloc[index]["Production"].strip() in row_to_use:
                 data = usgs_myb_static_varaibles()
-                data["SourceName"] = args["source"]
-                data["Year"] = str(args["year"])
+                data["SourceName"] = source
+                data["Year"] = str(year)
                 data["Unit"] = "Metric Tons"
                 data['FlowName'] = name + " " + product
                 data["Description"] = des
                 data["ActivityProducedBy"] = name
-                col_name = usgs_myb_year(SPAN_YEARS, args["year"])
+                col_name = usgs_myb_year(SPAN_YEARS, year)
                 if str(df.iloc[index][col_name]) == "--" or \
                         str(df.iloc[index][col_name]) == "(3)":
                     data["FlowAmount"] = str(0)
@@ -152,5 +148,5 @@ def usgs_zirconium_parse(dataframe_list, args):
                     data["FlowAmount"] = str(df.iloc[index][col_name])
                 dataframe = dataframe.append(data, ignore_index=True)
                 dataframe = assign_fips_location_system(
-                    dataframe, str(args["year"]))
+                    dataframe, str(year))
     return dataframe

--- a/flowsa/data_source_scripts/USGS_SPARROW.py
+++ b/flowsa/data_source_scripts/USGS_SPARROW.py
@@ -102,7 +102,7 @@ def name_replace(df_legend, df_raw):
     return df_raw
 
 
-def sparrow_url_helper(build_url, config, args):
+def sparrow_url_helper(*, build_url, config, **_):
     """
     This helper function uses the "build_url" input from flowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -111,8 +111,6 @@ def sparrow_url_helper(build_url, config, args):
     obtained.
     :param build_url: string, base url
     :param config: dictionary, items in FBA method yaml
-    :param args: dictionary, arguments specified when running flowbyactivity.py
-        flowbyactivity.py ('year' and 'source')
     :return: list, urls to call, concat, parse, format into Flow-By-Activity
         format
     """
@@ -126,17 +124,15 @@ def sparrow_url_helper(build_url, config, args):
     return urls
 
 
-def sparrow_call(url, response_load, args):
+def sparrow_call(*, resp, url, **_):
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
+    :param resp: df, response from url call
     :param url: string, url
-    :param response_load: df, response from url call
-    :param args: dictionary, arguments specified when running
-        flowbyactivity.py ('year' and 'source')
     :return: pandas dataframe of original source data
     """
-    text = response_load.content
+    text = resp.content
 
     ph = ['5cbf5150e4b09b8c0b700df3?f=__disk__bf%2F73%2F1f%2Fbf731fdf4e984'
           'a5cf50c0f1a140cda366cb8c1d3',
@@ -251,25 +247,24 @@ def sparrow_call(url, response_load, args):
     return df1
 
 
-def sparrow_parse(dataframe_list, args):
+def sparrow_parse(*, df_list, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param df_list: list of dataframes to concat and format
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
     df = pd.DataFrame()
     dataframe = pd.DataFrame()
-    for df in dataframe_list:
+    for df in df_list:
         df["Compartment "] = "ground"
         df["Class"] = "Chemicals"
         df["SourceName"] = "USGS_SPARROW"
         df["LocationSystem"] = 'HUC'
-        df["Year"] = str(args["year"])
+        df["Year"] = str(year)
         df["ActivityConsumedBy"] = None
 
-    dataframe = pd.concat(dataframe_list, ignore_index=True)
+    dataframe = pd.concat(df_list, ignore_index=True)
 
     return dataframe

--- a/flowsa/data_source_scripts/USGS_WU_Coef.py
+++ b/flowsa/data_source_scripts/USGS_WU_Coef.py
@@ -16,12 +16,10 @@ from flowsa.settings import externaldatapath
 from flowsa.flowbyfunctions import assign_fips_location_system
 
 
-def usgs_coef_parse(dataframe_list, args):
+def usgs_coef_parse(*, year, **_):
     """
     Combine, parse, and format the provided dataframes
-    :param dataframe_list: list of dataframes to concat and format
-    :param args: dictionary, used to run flowbyactivity.py
-        ('year' and 'source')
+    :param year: year
     :return: df, parsed and partially formatted to flowbyactivity
         specifications
     """
@@ -42,7 +40,7 @@ def usgs_coef_parse(dataframe_list, args):
     df["Class"] = "Water"
     df["SourceName"] = "USGS_WU_Coef"
     df["Location"] = US_FIPS
-    df['Year'] = args['year']
+    df['Year'] = year
     df = assign_fips_location_system(df, '2005')
     df["Unit"] = "gallons/animal/day"
     df['DataReliability'] = 5  # tmp

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -69,8 +69,7 @@ def assemble_urls_for_query(*, source, year, config):
         build_url = urlinfo['base_url']
 
     # substitute year from arguments and users api key into the url
-    if "__year__" in build_url:
-        build_url = build_url.replace("__year__", str(year))
+    build_url = build_url.replace("__year__", str(year))
     if "__apiKey__" in build_url:
         userAPIKey = load_api_key(config['api_name'])  # (common.py fxn)
         build_url = build_url.replace("__apiKey__", userAPIKey)

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -51,14 +51,15 @@ def assemble_urls_for_query(*, source, year, config):
     """
     Calls on helper functions defined in source.py files to
     replace parts of the url string
-    :param build_url: str, base url
+    :param source: str, data source
+    :param year: str, year
     :param config: dictionary, FBA yaml
-    :param args: dictionary, load parameters 'source' and 'year'
     :return: list, urls to call data from
     """
     # if there are url parameters defined in the yaml,
     # then build a url, else use "base_url"
-    if (urlinfo := config['url']) == 'None':
+    urlinfo = config['url']
+    if urlinfo == 'None':
         return [None]
 
     if 'url_params' in urlinfo:
@@ -93,7 +94,8 @@ def call_urls(*, url_list, source, year, config):
     The processing method is specific to
     the data source, so this function relies on a function in source.py
     :param url_list: list, urls to call
-    :param args: dictionary, load parameters 'source' and 'year'
+    :param source: str, data source
+    :param year: str, year
     :param config: dictionary, FBA yaml
     :return: list, dfs to concat and parse
     """
@@ -130,7 +132,8 @@ def parse_data(*, df_list, source, year, config):
     Calls on functions defined in source.py files, as parsing rules
     are specific to the data source.
     :param df_list: list, dfs to concat and parse
-    :param args: dictionary, load parameters 'source' and 'year'
+    :param source: str, data source
+    :param year: str, year
     :param config: dictionary, FBA yaml
     :return: df, single df formatted to FBA
     """

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -59,7 +59,7 @@ def assemble_urls_for_query(*, source, year, config):
     # if there are url parameters defined in the yaml,
     # then build a url, else use "base_url"
     if (urlinfo := config['url']) == 'None':
-        return None
+        return [None]
 
     if 'url_params' in urlinfo:
         params = parse.urlencode(urlinfo['url_params'])

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -10,6 +10,7 @@ EX: --year 2015 --source USGS_NWIS_WU
 
 import argparse
 import pandas as pd
+from urllib import parse
 from esupy.processed_data_mgmt import write_df_to_file
 from esupy.remote import make_url_request
 from flowsa.common import log, load_api_key, \
@@ -36,54 +37,17 @@ def parse_args():
     return args
 
 
-def set_fba_name(datasource, year):
+def set_fba_name(source, year):
     """
     Generate name of FBA used when saving parquet
-    :param datasource: str, datasource
+    :param source: str, source
     :param year: str, year
     :return: str, name of parquet
     """
-    if year is not None:
-        name_data = datasource + "_" + str(year)
-    else:
-        name_data = datasource
-    return name_data
+    return source if year is None else f'{source}_{year}'
 
 
-def build_url_for_query(config, args):
-    """
-    Creates a base url which requires string substitutions that
-    depend on data source
-    :param config: dictionary, FBA yaml
-    :param args: dictionary, load parameters 'source' and 'year'
-    :return: base url used to load data
-    """
-    # if there are url parameters defined in the yaml,
-    # then build a url, else use "base_url"
-    urlinfo = config["url"]
-    if urlinfo != 'None':
-        if 'url_params' in urlinfo:
-            params = ""
-            for k, v in urlinfo['url_params'].items():
-                params = params+'&'+k+"="+str(v)
-
-        if 'url_params' in urlinfo:
-            build_url = "{0}{1}{2}".format(urlinfo['base_url'],
-                                           urlinfo['api_path'],
-                                           params)
-        else:
-            build_url = "{0}".format(urlinfo['base_url'])
-
-        # substitute year from arguments and users api key into the url
-        if "__year__" in build_url:
-            build_url = build_url.replace("__year__", str(args["year"]))
-        if "__apiKey__" in build_url:
-            userAPIKey = load_api_key(config['api_name'])  # (common.py fxn)
-            build_url = build_url.replace("__apiKey__", userAPIKey)
-        return build_url
-
-
-def assemble_urls_for_query(build_url, config, args):
+def assemble_urls_for_query(*, source, year, config):
     """
     Calls on helper functions defined in source.py files to
     replace parts of the url string
@@ -92,17 +56,37 @@ def assemble_urls_for_query(build_url, config, args):
     :param args: dictionary, load parameters 'source' and 'year'
     :return: list, urls to call data from
     """
+    # if there are url parameters defined in the yaml,
+    # then build a url, else use "base_url"
+    if (urlinfo := config['url']) == 'None':
+        return None
+
+    if 'url_params' in urlinfo:
+        params = parse.urlencode(urlinfo['url_params'])
+        build_url = urlinfo['base_url'] + urlinfo['api_path'] + params
+    else:
+        build_url = urlinfo['base_url']
+
+    # substitute year from arguments and users api key into the url
+    if "__year__" in build_url:
+        build_url = build_url.replace("__year__", str(year))
+    if "__apiKey__" in build_url:
+        userAPIKey = load_api_key(config['api_name'])  # (common.py fxn)
+        build_url = build_url.replace("__apiKey__", userAPIKey)
 
     if "url_replace_fxn" in config:
         # dynamically import and call on function
         urls = dynamically_import_fxn(
-            args['source'], config["url_replace_fxn"])(build_url, config, args)
+            source, config["url_replace_fxn"])(build_url=build_url,
+                                               source=source,
+                                               year=year,
+                                               config=config)
         return urls
     else:
         return [build_url]
 
 
-def call_urls(url_list, args, config):
+def call_urls(*, url_list, source, year, config):
     """
     This method calls all the urls that have been generated.
     It then calls the processing method to begin processing the returned data.
@@ -124,11 +108,15 @@ def call_urls(url_list, args, config):
     if url_list[0] is not None:
         for url in url_list:
             log.info("Calling %s", url)
-            r = make_url_request(url, set_cookies=set_cookies)
+            resp = make_url_request(url, set_cookies=set_cookies)
             if "call_response_fxn" in config:
                 # dynamically import and call on function
                 df = dynamically_import_fxn(
-                    args['source'], config["call_response_fxn"])(url, r, args)
+                    source, config["call_response_fxn"])(resp=resp,
+                                                         source=source,
+                                                         year=year,
+                                                         config=config,
+                                                         url=url)
             if isinstance(df, pd.DataFrame):
                 data_frames_list.append(df)
             elif isinstance(df, list):
@@ -137,11 +125,11 @@ def call_urls(url_list, args, config):
     return data_frames_list
 
 
-def parse_data(dataframe_list, args, config):
+def parse_data(*, df_list, source, year, config):
     """
     Calls on functions defined in source.py files, as parsing rules
     are specific to the data source.
-    :param dataframe_list: list, dfs to concat and parse
+    :param df_list: list, dfs to concat and parse
     :param args: dictionary, load parameters 'source' and 'year'
     :param config: dictionary, FBA yaml
     :return: df, single df formatted to FBA
@@ -149,12 +137,14 @@ def parse_data(dataframe_list, args, config):
     if "parse_response_fxn" in config:
         # dynamically import and call on function
         df = dynamically_import_fxn(
-            args['source'], config["parse_response_fxn"])(
-            dataframe_list=dataframe_list, args=args)
+            source, config["parse_response_fxn"])(df_list=df_list,
+                                                  source=source,
+                                                  year=year,
+                                                  config=config)
     return df
 
 
-def process_data_frame(df, source, year, config):
+def process_data_frame(*, df, source, year, config):
     """
     Process the given dataframe, cleaning, converting data, and
     writing the final parquet. This method was written to move code into a
@@ -196,17 +186,20 @@ def main(**kwargs):
     if len(kwargs) == 0:
         kwargs = parse_args()
 
+    source = kwargs['source']
+    year = kwargs['year']
+
     # assign yaml parameters (common.py fxn)
-    config = load_yaml_dict(kwargs['source'])
+    config = load_yaml_dict(source)
 
     log.info("Creating dataframe list")
     # year input can either be sequential years (e.g. 2007-2009) or single year
-    if '-' in str(kwargs['year']):
-        years = str(kwargs['year']).split('-')
+    if '-' in str(year):
+        years = str(year).split('-')
         year_iter = list(range(int(years[0]), int(years[1]) + 1))
     else:
         # Else only a single year defined, create an array of one:
-        year_iter = [kwargs['year']]
+        year_iter = [year]
 
     # check that year(s) are listed in the method yaml, return warning if not
     years_list = list(set(list(map(int, year_iter))
@@ -216,17 +209,17 @@ def main(**kwargs):
                     f'data might not exist')
 
     for p_year in year_iter:
-        kwargs['year'] = str(p_year)
-        # build the base url with strings that will be replaced
-        build_url = build_url_for_query(config, kwargs)
+        year = str(p_year)
         # replace parts of urls with specific instructions from source.py
-        urls = assemble_urls_for_query(build_url, config, kwargs)
+        urls = assemble_urls_for_query(source=source, year=year, config=config)
         # create a list with data from all source urls
-        dataframe_list = call_urls(urls, kwargs, config)
+        df_list = call_urls(url_list=urls,
+                            source=source, year=year, config=config)
         # concat the dataframes and parse data with specific
         # instructions from source.py
         log.info("Concat dataframe list and parse data")
-        dfs = parse_data(dataframe_list, kwargs, config)
+        dfs = parse_data(df_list=df_list,
+                         source=source, year=year, config=config)
         if isinstance(dfs, list):
             for frame in dfs:
                 if not len(frame.index) == 0:
@@ -234,11 +227,12 @@ def main(**kwargs):
                         source_names = frame['SourceName']
                         source_name = source_names.iloc[0]
                     except KeyError:
-                        source_name = kwargs['source']
-                    process_data_frame(frame, source_name,
-                                       kwargs['year'], config)
+                        source_name = source
+                    process_data_frame(df=frame,
+                                       source=source_name, year=year,
+                                       config=config)
         else:
-            process_data_frame(dfs, kwargs['source'], kwargs['year'], config)
+            process_data_frame(df=dfs, source=source, year=year, config=config)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements a new optional entry in `source.yaml` files. If a `source.yaml` file contains the key `inherits_from`, the value associated with this key is interpreted as the name of another `.yaml` file in the same folder which should be read in and combined with the original `source.yaml` file to produce the `config` dictionary.

Merging the dictionaries is done such that if `parent.yaml` and `child.yaml` contain the same key, the value from `child.yaml` will be the one used in `config`. A warning is logged in this situation so the user will be aware.

Additionally, inheritance is allowed to be recursive: `parent.yaml` may have the entry `inherits_from: grandparent.yaml`, and so on.

This should be helpful for sources like EQUATES and NEI which would otherwise have a lot of duplicated information across `.yaml` files. Now, for example, all common information for EQUATES can be held in `EQUATES_Common.yaml`, with nonpoint source specific information in `EQUATES_Nonpoint.yaml`. In this case, `EQUATES_Nonpoint.yaml` contains the entry `inherits_from: EQUATES_Common`.