### PR TITLE
Make FBS use load_yaml_dict from common

### DIFF
--- a/flowsa/bibliography.py
+++ b/flowsa/bibliography.py
@@ -9,11 +9,11 @@ import os
 import pandas as pd
 from bibtexparser.bwriter import BibTexWriter
 from bibtexparser.bibdatabase import BibDatabase
-from flowsa.flowbysector import load_method
 from flowsa.common import load_yaml_dict, \
     load_values_from_literature_citations_config, \
     load_fbs_methods_additional_fbas_config, \
-    load_functions_loading_fbas_config, get_flowsa_base_name, sourceconfigpath
+    load_functions_loading_fbas_config, get_flowsa_base_name, \
+    sourceconfigpath, load_yaml_dict
 from flowsa.settings import outputpath, biboutputpath, log
 
 
@@ -25,7 +25,7 @@ def generate_list_of_sources_in_fbs_method(methodname):
     """
     sources = []
     # load the fbs method yaml
-    fbs_yaml = load_method(methodname)
+    fbs_yaml = load_yaml_dict(methodname, flowbytype='FBS')
 
     # create list of data and allocation data sets
     fbs = fbs_yaml['source_names']
@@ -82,7 +82,7 @@ def load_source_dict(sourcename):
         # else check if file exists, then try loading
         # citation information from source yaml
         sourcename = get_flowsa_base_name(sourceconfigpath, sourcename, "yaml")
-        config = load_yaml_dict(sourcename)
+        config = load_yaml_dict(sourcename, flowbytype='FBA')
 
     return config
 
@@ -127,7 +127,7 @@ def generate_fbs_bibliography(methodname):
                 # when different source names
                 try:
                     if (config['source_name'], config['author'], source[1],
-                    config['source_url']) not in source_set:
+                            config['source_url']) not in source_set:
                         source_set.add((config['source_name'],
                                         config['author'],
                                         source[1],

--- a/flowsa/common.py
+++ b/flowsa/common.py
@@ -89,7 +89,7 @@ def load_yaml_dict(filename, flowbytype=None):
     Load the information in 'source_catalog.yaml'
     :return: dictionary containing all information in source_catalog.yaml
     """
-    if filename == 'source_config':
+    if filename == 'source_catalog':
         folder = datapath
     else:
         if flowbytype == 'FBA':

--- a/flowsa/common.py
+++ b/flowsa/common.py
@@ -20,7 +20,7 @@ from flowsa.schema import flow_by_activity_fields, flow_by_sector_fields, \
     flow_by_activity_wsec_fields, flow_by_activity_mapped_wsec_fields, \
     activity_fields
 from flowsa.settings import datapath, MODULEPATH, logoutputpath, \
-    sourceconfigpath, log
+    sourceconfigpath, log, flowbysectormethodpath
 
 
 # Sets default Sector Source Name
@@ -84,16 +84,27 @@ def load_crosswalk(crosswalk_name):
     return cw
 
 
-def load_yaml_dict(filename):
+def load_yaml_dict(filename, flowbytype=None):
     """
     Load the information in 'source_catalog.yaml'
     :return: dictionary containing all information in source_catalog.yaml
     """
-    folder = datapath if filename == 'source_catalog' else sourceconfigpath
+    if filename == 'source_config':
+        folder = datapath
+    else:
+        if flowbytype == 'FBA':
+            folder = sourceconfigpath
+        elif flowbytype == 'FBS':
+            folder = flowbysectormethodpath
+        else:
+            raise KeyError('Must specify either \'FBA\' or \'FBS\'')
     yaml_path = folder + filename + '.yaml'
 
-    with open(yaml_path, 'r') as f:
-        config = yaml.safe_load(f)
+    try:
+        with open(yaml_path, 'r') as f:
+            config = yaml.safe_load(f)
+    except IOError:
+        log.error('%s method file not found', flowbytype)
 
     # Allow for .yaml files to recursively inherit other .yaml files. Keys in
     # children will overwrite the same key from a parent.

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -192,7 +192,7 @@ def main(**kwargs):
     year = kwargs['year']
 
     # assign yaml parameters (common.py fxn)
-    config = load_yaml_dict(source)
+    config = load_yaml_dict(source, flowbytype='FBA')
 
     log.info("Creating dataframe list")
     # year input can either be sequential years (e.g. 2007-2009) or single year

--- a/flowsa/flowbysector.py
+++ b/flowsa/flowbysector.py
@@ -29,7 +29,7 @@ from flowsa.common import fips_number_key, load_yaml_dict, \
     str2bool, fba_activity_fields, rename_log_file, \
     fbs_activity_fields, fba_fill_na_dict, fbs_fill_na_dict, \
     fbs_default_grouping_fields, fbs_grouping_fields_w_activities, \
-    logoutputpath
+    logoutputpath, load_yaml_dict
 from flowsa.schema import flow_by_activity_fields, flow_by_sector_fields, \
     flow_by_sector_fields_w_activity
 from flowsa.settings import log, vLog, flowbysectormethodpath, \
@@ -66,21 +66,6 @@ def parse_args():
                          "rather than generating the FBAs in FLOWSA.")
     args = vars(ap.parse_args())
     return args
-
-
-def load_method(method_name):
-    """
-    Loads a flowbysector method from a YAML
-    :param method_name: str, FBS method name (ex. 'Water_national_m1_2015')
-    :return: dictionary, items in the FBS method yaml
-    """
-    sfile = flowbysectormethodpath + method_name + '.yaml'
-    try:
-        with open(sfile, 'r') as f:
-            method = yaml.safe_load(f)
-    except IOError:
-        log.error("FlowBySector method file not found.")
-    return method
 
 
 def load_source_dataframe(sourcename, source_dict, download_FBA_if_missing):
@@ -139,7 +124,7 @@ def main(**kwargs):
     # assign arguments
     vLog.info("Initiating flowbysector creation for %s", method_name)
     # call on method
-    method = load_method(method_name)
+    method = load_yaml_dict(method_name, flowbytype='FBS')
     # create dictionary of data and allocation datasets
     fb = method['source_names']
     # Create empty list for storing fbs files


### PR DESCRIPTION
This PR expands the `common.py` function `load_yaml_dict()` to let it read in flow by sector `.yaml`s as well as flow by activity `.yaml`s. The `flowbysector.py` function `load_method()` is removed and replaced with `load_yaml_dict()` from `common.py`.