### PR TITLE
Fixed equates_call()

### DIFF
--- a/flowsa/data_source_scripts/EPA_EQUATES.py
+++ b/flowsa/data_source_scripts/EPA_EQUATES.py
@@ -51,7 +51,7 @@ def equates_call(*, resp, year, config, **_):
             tar.getmembers()  # Index the tarball
             df_list = [pd.read_csv(BytesIO(tar.extractfile(file).read()),
                                    comment='#')
-                       for file in config['file_list'][year]]
+                       for file in config['file_list'][int(year)]]
             return pd.concat(df_list)
 
 


### PR DESCRIPTION
This little fix seemed to be necessary to enable proper reading of the `.yaml` config file.