### PR TITLE
New action to test generation of FBS on pull requests ✅ 

### DIFF
--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: ${{ LD_LIBRARY_PATH }}/**/fbs_diff/*_diff.csv
+        path: ${{ env.LD_LIBRARY_PATH }}/**/fbs_diff/*_diff.csv
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: ~/fba_diff/*_diff.csv
+        path: ~/fbs_diff/*_diff.csv
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -1,0 +1,46 @@
+# This workflow generates FlowBySector files and compares to the latest public version
+
+name: Validate FlowBySectors
+
+on:
+  push:
+  pull_request:
+    branches: [master, develop]
+    types: [opened, reopened]   # excludes syncronize to avoid redundant trigger from commits on PRs
+  workflow_dispatch:            # also allow manual trigger, for testing purposes
+
+jobs:
+  build:
+    runs-on: ubunut-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Update pip & install testing pkgs
+      run: |
+        python -VV
+        python -m pip install --upgrade pip setuptools wheel
+        pip install pytest pytest-cov flake8
+
+    # install package & dependencies
+    - name: Install package and dependencies
+      run: |
+        pip install .
+
+    - name: Compare FBS with remote
+      run: |
+        python flowsa.test_examples.test_FBS_against_remote
+
+    - name: Upload csv files
+      uses: actions/upload-artifact@v2.3.0
+      with:
+        # Artifact name
+        name: FBS diff files
+        # A file, directory or wildcard patter that describes what to upload
+        path: "flowsa/data/fbs_diff/*.csv"
+        if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
+        # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Compare FBS with remote
       run: |
-        python test_examples.test_FBS_against_remote
+        python test_FBS_against_remote.py
 
     - name: Upload csv files
       uses: actions/upload-artifact@v2.3.0

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: "flowsa/data/fbs_diff/*.csv"
+        path: flowsa/data/fbs_diff/*_diff.csv
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: ~/fbs_diff/*_diff.csv
+        path: ~/**/fbs_diff/*_diff.csv
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -3,7 +3,7 @@
 name: Validate FlowBySectors
 
 on:
-  push: # temporary
+  # push: # removed to run only on pull request
   pull_request:
     branches: [master, develop]
     types: [opened, reopened]   # excludes syncronize to avoid redundant trigger from commits on PRs

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -3,7 +3,6 @@
 name: Validate FlowBySectors
 
 on:
-  push:
   pull_request:
     branches: [master, develop]
     types: [opened, reopened]   # excludes syncronize to avoid redundant trigger from commits on PRs

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubunut-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: "data/fbs_diff/*.csv"
+        path: "flowsa/data/fbs_diff/*.csv"
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -3,6 +3,7 @@
 name: Validate FlowBySectors
 
 on:
+  push: # temporary
   pull_request:
     branches: [master, develop]
     types: [opened, reopened]   # excludes syncronize to avoid redundant trigger from commits on PRs

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Compare FBS with remote
       run: |
-        python test_FBS_against_remote.py
+        python flowsa/test_FBS_against_remote.py
 
     - name: Upload csv files
       uses: actions/upload-artifact@v2.3.0

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: flowsa/data/fbs_diff/*_diff.csv
+        path: ~/fba_diff/*_diff.csv
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: ~/**/fbs_diff/*_diff.csv
+        path: ${{ LD_LIBRARY_PATH }}/**/fbs_diff/*_diff.csv
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: ${{ env.LD_LIBRARY_PATH }}/**/fbs_diff/*_diff.csv
+        path: ${{ env.LD_LIBRARY_PATH }}/python3.10/site-packages/flowsa/data/fbs_diff/*_diff.csv
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/compare_FBS_to_remote.yml
+++ b/.github/workflows/compare_FBS_to_remote.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Compare FBS with remote
       run: |
-        python flowsa.test_examples.test_FBS_against_remote
+        python test_examples.test_FBS_against_remote
 
     - name: Upload csv files
       uses: actions/upload-artifact@v2.3.0
@@ -41,6 +41,6 @@ jobs:
         # Artifact name
         name: FBS diff files
         # A file, directory or wildcard patter that describes what to upload
-        path: "flowsa/data/fbs_diff/*.csv"
+        path: "data/fbs_diff/*.csv"
         if-no-files-found: warn # 'warn' or 'ignore' are also available, defaults to `warn`
         # retention-days: 5 # cannot exceed the retention limit set by the repository, organization, or enterprise.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,7 +6,7 @@ name: Python CI/CD tests
 
 on:
   push:
-    branches: [master, develop]
+    # branches: [master, develop]
     paths-ignore:               # prevents workflow execution when only these types of files are modified
       - '**.md'                 # wildcards prevent file in any repo dir from trigering workflow
       - '**.bib'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint 
+# This workflow will install Python dependencies, run tests and lint
 # across operating systems, select versions of Python, and user + dev environments
 # For more info see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
@@ -6,7 +6,7 @@ name: Python CI/CD tests
 
 on:
   push:
-    # branches: [master, develop]
+    branches: [master, develop]
     paths-ignore:               # prevents workflow execution when only these types of files are modified
       - '**.md'                 # wildcards prevent file in any repo dir from trigering workflow
       - '**.bib'
@@ -15,9 +15,9 @@ on:
       - '.gitignore'
   pull_request:
     branches: [master, develop]
-    types: [opened, reopened]   # excludes syncronize to avoid redundant trigger from commits on PRs 
+    types: [opened, reopened]   # excludes syncronize to avoid redundant trigger from commits on PRs
     paths-ignore:
-      - '**.md'  
+      - '**.md'
       - '**.bib'
       - '**.ya?ml'
       - 'LICENSE'
@@ -32,33 +32,33 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         py-version: ['3.7', '3.8', '3.9', '3.10']
-        
+
     steps:
     - uses: actions/checkout@v2
-    
+
     # general Python setup
     - name: Set up Python ${{ matrix.py-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.py-version }}
-        
+
     - name: Update pip & install testing pkgs
       run: |
         python -VV
         python -m pip install --upgrade pip setuptools wheel
         pip install pytest pytest-cov flake8
-        
+
     # install package & dependencies
     - name: Install package and dependencies
       run: |
         pip install .
-        
+
     # linting & pytest
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        
+
     - name: Test with pytest
       run: |
         pytest --doctest-modules

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 *__pycache__
 *.egg*
 *.cache
+**/data/fbs_diff/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft flowsa/data
+graft flowsa/methods

--- a/flowsa/__init__.py
+++ b/flowsa/__init__.py
@@ -167,10 +167,11 @@ def writeFlowBySectorBibliography(methodname):
     generate_fbs_bibliography(methodname)
 
 
-def seeAvailableFlowByModels(flowbytype):
+def seeAvailableFlowByModels(flowbytype, print_method=True):
     """
     Return available Flow-By-Activity or Flow-By-Sector models
     :param flowbytype: 'FBA' or 'FBS'
+    :param print_method: False to skip printing to console
     :return: console printout of available models
     """
 
@@ -206,8 +207,9 @@ def seeAvailableFlowByModels(flowbytype):
     else:
         data_print = fb_df
 
-    # print data in human-readable format
-    pprint.pprint(data_print, width=79, compact=True)
+    if print_method:
+        # print data in human-readable format
+        pprint.pprint(data_print, width=79, compact=True)
     return data_print
 
 

--- a/flowsa/allocation.py
+++ b/flowsa/allocation.py
@@ -329,7 +329,7 @@ def equally_allocate_parent_to_child_naics(df_load, target_sector_level):
                                      'represented in current data subset: '
                                      '{}'.format(' '.join(map(str, rl_list))),
                                      str(i))
-                rows_lost = rows_lost.append(rl_m3, ignore_index=True)
+                rows_lost = pd.concat([rows_lost, rl_m3], ignore_index=True)
 
     if len(rows_lost) != 0:
         vLogDetailed.info('Allocating FlowAmounts equally to '

--- a/flowsa/data_source_scripts/EIA_MECS.py
+++ b/flowsa/data_source_scripts/EIA_MECS.py
@@ -574,7 +574,7 @@ def determine_flows_requiring_disaggregation(
             df_both3 = df_both3.drop(columns=['SubtractFlow'])
             # drop rows where 0
             # df_both = df_both[df_both['FlowAmount'] != 0]
-            df_merged = df_merged.append(df_both3, ignore_index=True)
+            df_merged = pd.concat([df_merged, df_both3], ignore_index=True)
         df_right = df_m[df_m['_merge'] == 'right_only']
         if len(df_right) != 0:
             df_right = df_right.drop(
@@ -587,7 +587,8 @@ def determine_flows_requiring_disaggregation(
             # reorder
             df_right = df_right[['FlowAmount', 'Location',
                                  sector_column, 'SectorMatch']]
-            df_not_merged = df_not_merged.append(df_right, ignore_index=True)
+            df_not_merged = pd.concat([df_not_merged, df_right],
+                                      ignore_index=True)
     # rename the flowamount column
     df_merged = df_merged.rename(columns={'FlowAmount': 'FlowAmountNew',
                                           sector_column: activity_column})

--- a/flowsa/data_source_scripts/USDA_IWMS.py
+++ b/flowsa/data_source_scripts/USDA_IWMS.py
@@ -143,7 +143,7 @@ def disaggregate_iwms_to_6_digit_naics_for_water_withdrawal(df, attr, method,
     # applying to multiply NAICS
     df.drop_duplicates(subset=['FlowName', 'FlowAmount', 'Compartment',
                                'Location'], keep='first', inplace=True)
-    years = [attr['allocation_source_year'] - 1]
+    years = attr['allocation_source_year'] - 1
     df = df[~df[sector_column].isna()].reset_index(drop=True)
     # drop aquaculture when disaggregating pastureland because water use for
     # aquaculture calculated separately

--- a/flowsa/data_source_scripts/USGS_NWIS_WU.py
+++ b/flowsa/data_source_scripts/USGS_NWIS_WU.py
@@ -599,7 +599,8 @@ def check_golf_and_crop_irrigation_totals(df_load):
                                 'Crop_ACB', 'subset_sum', 'Diff'])
 
     if len(df_m3) != 0:
-        df_w_missing_crop = df_load.append(df_m3, sort=True, ignore_index=True)
+        df_w_missing_crop = pd.concat([df_load, df_m3], sort=True,
+                                      ignore_index=True)
         return df_w_missing_crop
     else:
         return df_load

--- a/flowsa/data_source_scripts/stewiFBS.py
+++ b/flowsa/data_source_scripts/stewiFBS.py
@@ -256,7 +256,8 @@ def extract_facility_data(inventory_dict):
                       inventory_name)
             facilities.drop_duplicates(subset='FacilityID',
                                        keep='first', inplace=True)
-        facility_mapping = facility_mapping.append(facilities)
+        facility_mapping = pd.concat([facility_mapping, facilities],
+                                     ignore_index=True)
 
     # Apply FIPS to facility locations
     facility_mapping = apply_county_FIPS(facility_mapping)

--- a/flowsa/data_source_scripts/stewiFBS.py
+++ b/flowsa/data_source_scripts/stewiFBS.py
@@ -62,7 +62,8 @@ def stewicombo_to_sector(yaml_load):
 
     df = None
     if inventory_name is not None:
-        df = stewicombo.getInventory(inventory_name, True)
+        df = stewicombo.getInventory(inventory_name,
+                                     download_if_missing=True)
     if df is None:
         # run stewicombo to combine inventories, filter for LCI, remove overlap
         log.info('generating inventory in stewicombo')
@@ -139,7 +140,8 @@ def stewi_to_sector(yaml_load):
     df = pd.DataFrame()
     for database, year in yaml_load['inventory_dict'].items():
         inv = stewi.getInventory(
-            database, year, filter_for_LCI=True, US_States_Only=True)
+            database, year, filters=['filter_for_LCI', 'US_States_only'],
+            download_if_missing=True)
         inv['Year'] = year
         inv['MetaSources'] = database
         df = df.append(inv)
@@ -189,7 +191,8 @@ def reassign_airplane_emissions(df, year, NAICS_level_value):
 
     # obtain and prepare SCC dataset
     df_airplanes = stewi.getInventory('NEI', year,
-                                      stewiformat='flowbyprocess')
+                                      stewiformat='flowbyprocess',
+                                      download_if_missing=True)
     df_airplanes = df_airplanes[df_airplanes['Process'] ==
                                 air_transportation_SCC]
     df_airplanes['Source'] = 'NEI'
@@ -244,7 +247,8 @@ def extract_facility_data(inventory_dict):
         database = inventory_list[i]
         year = list(inventory_dict.values())[i]
         inventory_name = database + '_' + year
-        facilities = stewi.getInventoryFacilities(database, year)
+        facilities = stewi.getInventoryFacilities(database, year,
+                                                  download_if_missing=True)
         facilities = facilities[['FacilityID', 'State', 'County', 'NAICS']]
         if len(facilities[facilities.duplicated(
                 subset='FacilityID', keep=False)]) > 0:
@@ -271,7 +275,8 @@ def obtain_NAICS_from_facility_matcher(inventory_list):
     # Access NAICS From facility matcher and assign based on FRS_ID
     all_NAICS = \
         facilitymatcher.get_FRS_NAICSInfo_for_facility_list(
-            frs_id_list=None, inventories_of_interest_list=inventory_list)
+            frs_id_list=None, inventories_of_interest_list=inventory_list,
+            download_if_missing=True)
     all_NAICS = all_NAICS.loc[all_NAICS['PRIMARY_INDICATOR'] == 'PRIMARY']
     all_NAICS.drop(columns=['PRIMARY_INDICATOR'], inplace=True)
     all_NAICS = naics_expansion(all_NAICS)

--- a/flowsa/flowbyfunctions.py
+++ b/flowsa/flowbyfunctions.py
@@ -260,7 +260,7 @@ def sector_aggregation(df_load, group_cols):
             agg_sectors = aggregator(dfm, group_cols)
             # append to df
             agg_sectors = replace_NoneType_with_empty_cells(agg_sectors)
-            df = df.append(agg_sectors, sort=False).reset_index(drop=True)
+            df = pd.concat([df, agg_sectors], ignore_index=True)
     df = df.drop_duplicates()
 
     # if activities are source-like, set col values as
@@ -532,9 +532,11 @@ def return_activity_from_scale(df, provided_from_scale):
                 unique_activities_sub, unique_activities_i, which='both')
 
             # append unique activities and df with defined activity_from_scale
-            unique_activities_sub = unique_activities_sub.append(
-                df_missing_i[[fba_activity_fields[0], fba_activity_fields[1]]])
-            df_existing = df_existing.append(df_missing_i)
+            unique_activities_sub = pd.concat([unique_activities_sub,
+                df_missing_i[[fba_activity_fields[0], fba_activity_fields[1]]]],
+                                              ignore_index=True)
+            df_existing = pd.concat([df_existing, df_missing_i],
+                                    ignore_index=True)
             df_missing = dataframe_difference(
                 df_missing[[fba_activity_fields[0], fba_activity_fields[1]]],
                 df_existing_i[[fba_activity_fields[0],

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -19,6 +19,7 @@ def test_FBS_against_remote():
     for m in seeAvailableFlowByModels("FBS"):
         if m.startswith('CAP_HAP_'): continue
         if m.startswith('Water_'): continue
+        if m !='GRDREL_national_2017': continue
         status = download_from_remote(set_fb_meta(m, "FlowBySector"),
                                       paths)
 
@@ -28,7 +29,7 @@ def test_FBS_against_remote():
 
         df = compare_FBS_results(m, m, compare_to_remote=True)
         if len(df) > 0:
-            print(f"Saving differences in {m}")
+            print(f"Saving differences in {m} to {outdir}")
             df.to_csv(f"{outdir}{m}_diff.csv", index=False)
         else:
             print(f"No differences found in {m}")

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -16,20 +16,21 @@ def test_FBS_against_remote():
     outdir = f"{datapath}fbs_diff/"
     if not os.path.exists(outdir):
         os.mkdir(outdir)
-    for m in seeAvailableFlowByModels("FBS"):
+    for m in seeAvailableFlowByModels("FBS", print_method=False):
         status = download_from_remote(set_fb_meta(m, "FlowBySector"),
                                       paths)
-
         if not status:
             print(f"{m} not found in remote server. Skipping...")
             continue
-
+        print("--------------------------------\n"
+              f"Method: {m}\n"
+              "--------------------------------")
         df = compare_FBS_results(m, m, compare_to_remote=True)
         if len(df) > 0:
-            print(f"Saving differences in {m} to {outdir}")
+            print(f"Saving differences in {m} to csv")
             df.to_csv(f"{outdir}{m}_diff.csv", index=False)
         else:
-            print(f"No differences found in {m}")
+            print(f"***No differences found in {m}***")
 
 if __name__ == "__main__":
     test_FBS_against_remote()

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -25,7 +25,7 @@ def test_FBS_against_remote():
             print(f"{m} not found in remote server. Skipping...")
             continue
 
-        df = compare_FBS_results(m, m, download=True)
+        df = compare_FBS_results(m, m, compare_to_remote=True)
         if len(df) > 0:
             print(f"Saving differences in {m}")
             df.to_csv(f"{outdir}{m}_diff.csv", index=False)

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -26,6 +26,9 @@ def test_FBS_against_remote():
               f"Method: {m}\n"
               "--------------------------------")
         df = compare_FBS_results(m, m, compare_to_remote=True)
+        df.rename(columns = {'FlowAmount_fbs1': 'FlowAmount_remote',
+                             'FlowAmount_fbs2': 'FlowAmount_HEAD'},
+                  inplace=True)
         if len(df) > 0:
             print(f"Saving differences in {m} to csv")
             df.to_csv(f"{outdir}{m}_diff.csv", index=False)

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -1,0 +1,38 @@
+"""
+Tests to run during github action
+"""
+import pytest
+import os
+import flowsa
+from flowsa.metadata import set_fb_meta
+from esupy.processed_data_mgmt import download_from_remote
+
+@pytest.mark.skip(reason="Perform targeted test for compare_FBS on PR")
+def test_FBS_against_remote():
+    """Compare results for each FBS method at current HEAD with most
+    recent FBS stored on remote server."""
+    outdir = f"{flowsa.settings.datapath}fbs_diff/"
+    if not os.path.exists(outdir):
+        os.mkdir(outdir)
+    with os.scandir(flowsa.settings.flowbysectormethodpath) as files:
+        for method in files:
+            if method.name.endswith(".yaml"):
+                m = method.name.split(".yaml")[0]
+                if m.startswith('CAP_HAP_'): continue
+                status = download_from_remote(set_fb_meta(m, "FlowBySector"),
+                                              flowsa.settings.paths)
+
+                if not status:
+                    print(f"{m} not found in remote server. Skipping...")
+                    continue
+
+                df = flowsa.validation.compare_FBS_results(m, m,
+                                                           download=True)
+                if len(df) > 0:
+                    print(f"Saving differences in {m}")
+                    df.to_csv(f"{outdir}{m}_diff.csv", index=False)
+                else:
+                    print(f"No differences found in {m}")
+
+if __name__ == "__main__":
+    test_FBS_against_remote()

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -5,29 +5,31 @@ import pytest
 import os
 import flowsa
 from flowsa.metadata import set_fb_meta
+from flowsa.settings import flowbysectormethodpath, paths,\
+    datapath
+from flowsa.validation import compare_FBS_results
 from esupy.processed_data_mgmt import download_from_remote
 
 @pytest.mark.skip(reason="Perform targeted test for compare_FBS on PR")
 def test_FBS_against_remote():
     """Compare results for each FBS method at current HEAD with most
     recent FBS stored on remote server."""
-    outdir = f"{flowsa.settings.datapath}fbs_diff/"
+    outdir = f"{datapath}fbs_diff/"
     if not os.path.exists(outdir):
         os.mkdir(outdir)
-    with os.scandir(flowsa.settings.flowbysectormethodpath) as files:
+    with os.scandir(flowbysectormethodpath) as files:
         for method in files:
             if method.name.endswith(".yaml"):
                 m = method.name.split(".yaml")[0]
                 if m.startswith('CAP_HAP_'): continue
                 status = download_from_remote(set_fb_meta(m, "FlowBySector"),
-                                              flowsa.settings.paths)
+                                              paths)
 
                 if not status:
                     print(f"{m} not found in remote server. Skipping...")
                     continue
 
-                df = flowsa.validation.compare_FBS_results(m, m,
-                                                           download=True)
+                df = compare_FBS_results(m, m, download=True)
                 if len(df) > 0:
                     print(f"Saving differences in {m}")
                     df.to_csv(f"{outdir}{m}_diff.csv", index=False)

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -3,10 +3,9 @@ Tests to run during github action
 """
 import pytest
 import os
-import flowsa
+from flowsa import seeAvailableFlowByModels
 from flowsa.metadata import set_fb_meta
-from flowsa.settings import flowbysectormethodpath, paths,\
-    datapath
+from flowsa.settings import paths, datapath
 from flowsa.validation import compare_FBS_results
 from esupy.processed_data_mgmt import download_from_remote
 
@@ -17,24 +16,21 @@ def test_FBS_against_remote():
     outdir = f"{datapath}fbs_diff/"
     if not os.path.exists(outdir):
         os.mkdir(outdir)
-    with os.scandir(flowbysectormethodpath) as files:
-        for method in files:
-            if method.name.endswith(".yaml"):
-                m = method.name.split(".yaml")[0]
-                if m.startswith('CAP_HAP_'): continue
-                status = download_from_remote(set_fb_meta(m, "FlowBySector"),
-                                              paths)
+    for m in seeAvailableFlowByModels("FBS"):
+        if m.startswith('CAP_HAP_'): continue
+        status = download_from_remote(set_fb_meta(m, "FlowBySector"),
+                                      paths)
 
-                if not status:
-                    print(f"{m} not found in remote server. Skipping...")
-                    continue
+        if not status:
+            print(f"{m} not found in remote server. Skipping...")
+            continue
 
-                df = compare_FBS_results(m, m, download=True)
-                if len(df) > 0:
-                    print(f"Saving differences in {m}")
-                    df.to_csv(f"{outdir}{m}_diff.csv", index=False)
-                else:
-                    print(f"No differences found in {m}")
+        df = compare_FBS_results(m, m, download=True)
+        if len(df) > 0:
+            print(f"Saving differences in {m}")
+            df.to_csv(f"{outdir}{m}_diff.csv", index=False)
+        else:
+            print(f"No differences found in {m}")
 
 if __name__ == "__main__":
     test_FBS_against_remote()

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -18,6 +18,7 @@ def test_FBS_against_remote():
         os.mkdir(outdir)
     for m in seeAvailableFlowByModels("FBS"):
         if m.startswith('CAP_HAP_'): continue
+        if m.startswith('Water_'): continue
         status = download_from_remote(set_fb_meta(m, "FlowBySector"),
                                       paths)
 

--- a/flowsa/test_FBS_against_remote.py
+++ b/flowsa/test_FBS_against_remote.py
@@ -17,9 +17,6 @@ def test_FBS_against_remote():
     if not os.path.exists(outdir):
         os.mkdir(outdir)
     for m in seeAvailableFlowByModels("FBS"):
-        if m.startswith('CAP_HAP_'): continue
-        if m.startswith('Water_'): continue
-        if m !='GRDREL_national_2017': continue
         status = download_from_remote(set_fb_meta(m, "FlowBySector"),
                                       paths)
 

--- a/flowsa/test_examples.py
+++ b/flowsa/test_examples.py
@@ -1,11 +1,8 @@
 """
 Test functions work
 """
-import pytest
-import os
 import flowsa
-from flowsa.metadata import set_fb_meta
-from esupy.processed_data_mgmt import download_from_remote
+
 
 def test_get_flows_by_activity():
     flowsa.getFlowByActivity(datasource="EIA_MECS_Land", year=2014)
@@ -20,33 +17,3 @@ def test_get_flows_by_sector():
 def test_write_bibliography():
     flowsa.writeFlowBySectorBibliography('Water_national_2015_m1')
 
-
-@pytest.mark.skip(reason="Perform targeted test for compare_FBS on PR")
-def test_FBS_against_remote():
-    """Compare results for each FBS method at current HEAD with most
-    recent FBS stored on remote server."""
-    outdir = f"{flowsa.settings.datapath}fbs_diff/"
-    if not os.path.exists(outdir):
-        os.mkdir(outdir)
-    with os.scandir(flowsa.settings.flowbysectormethodpath) as files:
-        for method in files:
-            if method.name.endswith(".yaml"):
-                m = method.name.split(".yaml")[0]
-                if m.startswith('CAP_HAP_'): continue
-                status = download_from_remote(set_fb_meta(m, "FlowBySector"),
-                                              flowsa.settings.paths)
-
-                if not status:
-                    print(f"{m} not found in remote server. Skipping...")
-                    continue
-
-                df = flowsa.validation.compare_FBS_results(m, m,
-                                                           download=True)
-                if len(df) > 0:
-                    print(f"Saving differences in {m}")
-                    df.to_csv(f"{outdir}{m}_diff.csv", index=False)
-                else:
-                    print(f"No differences found in {m}")
-
-if __name__ == "__main__":
-    test_FBS_against_remote()

--- a/flowsa/test_examples.py
+++ b/flowsa/test_examples.py
@@ -1,9 +1,11 @@
 """
 Test functions work
 """
-
+import pytest
+import os
 import flowsa
-
+from flowsa.metadata import set_fb_meta
+from esupy.processed_data_mgmt import download_from_remote
 
 def test_get_flows_by_activity():
     flowsa.getFlowByActivity(datasource="EIA_MECS_Land", year=2014)
@@ -17,3 +19,34 @@ def test_get_flows_by_sector():
 
 def test_write_bibliography():
     flowsa.writeFlowBySectorBibliography('Water_national_2015_m1')
+
+
+@pytest.mark.skip(reason="Perform targeted test for compare_FBS on PR")
+def test_FBS_against_remote():
+    """Compare results for each FBS method at current HEAD with most
+    recent FBS stored on remote server."""
+    outdir = f"{flowsa.settings.datapath}fbs_diff/"
+    if not os.path.exists(outdir):
+        os.mkdir(outdir)
+    with os.scandir(flowsa.settings.flowbysectormethodpath) as files:
+        for method in files:
+            if method.name.endswith(".yaml"):
+                m = method.name.split(".yaml")[0]
+                if m.startswith('CAP_HAP_'): continue
+                status = download_from_remote(set_fb_meta(m, "FlowBySector"),
+                                              flowsa.settings.paths)
+
+                if not status:
+                    print(f"{m} not found in remote server. Skipping...")
+                    continue
+
+                df = flowsa.validation.compare_FBS_results(m, m,
+                                                           download=True)
+                if len(df) > 0:
+                    print(f"Saving differences in {m}")
+                    df.to_csv(f"{outdir}{m}_diff.csv", index=False)
+                else:
+                    print(f"No differences found in {m}")
+
+if __name__ == "__main__":
+    test_FBS_against_remote()

--- a/flowsa/validation.py
+++ b/flowsa/validation.py
@@ -808,23 +808,31 @@ def replace_naics_w_naics_from_another_year(df_load, sectorsourcename):
     return df
 
 
-def compare_FBS_results(fbs1_load, fbs2_load, ignore_metasources=False):
+def compare_FBS_results(fbs1, fbs2, ignore_metasources=False,
+                        compare_to_remote=False):
     """
     Compare a parquet on Data Commons to a parquet stored locally
-    :param fbs1_load: df, fbs format
-    :param fbs2_load: df, fbs format
+    :param fbs1: str, name of method 1
+    :param fbs2: str, name of method 2
     :param ignore_metasources: bool, True to compare fbs without
     matching metasources
+    :param compare_to_remote: bool, True to download fbs1 from remote and
+    compare to fbs2 generated here
     :return: df, comparison of the two dfs
     """
     import flowsa
 
-    # load first file (must be saved locally)
-    df1 = flowsa.getFlowBySector(fbs1_load).rename(
-        columns={'FlowAmount': 'FlowAmount_fbs1'})
+    # load first file
+    df1 = flowsa.getFlowBySector(fbs1,
+                                 download_FBS_if_missing=compare_to_remote
+                                 ).rename(columns={'FlowAmount': 'FlowAmount_fbs1'})
     df1 = replace_strings_with_NoneType(df1)
-    # load second file (must be saved locally)
-    df2 = flowsa.getFlowBySector(fbs2_load).rename(
+    # load second file
+    if compare_to_remote:
+        # Generate the FBS locally and then immediately load
+        flowsa.flowbysector.main(method=fbs2,
+                                 download_FBAs_if_missing=True)
+    df2 = flowsa.getFlowBySector(fbs2).rename(
         columns={'FlowAmount': 'FlowAmount_fbs2'})
     df2 = replace_strings_with_NoneType(df2)
     # compare df

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
+log_cli = True
+log_cli_level = INFO
 norecursedirs = build dist scripts examples
 addopts = --doctest-modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
-git+https://github.com/USEPA/standardizedinventories.git@remote_access#egg=StEWI
+git+https://github.com/USEPA/standardizedinventories.git@develop#egg=StEWI
 pandas>=1.3.2                  # Powerful data structures for data analysis, time series, and statistics.
 pip>=9                         # The PyPA recommended tool for installing Python packages.
 setuptools>=41                 # Fully-featured library designed to facilitate packaging Python projects.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
-git+https://github.com/USEPA/standardizedinventories.git@develop#egg=StEWI
+git+https://github.com/USEPA/standardizedinventories.git@remote_access#egg=StEWI
 pandas>=1.3.2                  # Powerful data structures for data analysis, time series, and statistics.
 pip>=9                         # The PyPA recommended tool for installing Python packages.
 setuptools>=41                 # Fully-featured library designed to facilitate packaging Python projects.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist',
         'esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
-        'StEWI @ git+https://github.com/USEPA/standardizedinventories.git@develop#egg=StEWI',
+        'StEWI @ git+https://github.com/USEPA/standardizedinventories.git@remote_access#egg=StEWI',
         'pandas>=1.3.2',
         'pip>=9',
         'setuptools>=41',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     version='1.1',
     packages=find_packages(),
     package_dir={'flowsa': 'flowsa'},
-    package_data={'flowsa': ["data/*.*"]},
+    package_data={'flowsa': ["data/*.*",
+                             "methods/*/*.*"]},
     include_package_data=True,
     install_requires=[
         'fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist',

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ setup(
     version='1.1',
     packages=find_packages(),
     package_dir={'flowsa': 'flowsa'},
-    package_data={'flowsa': ["data/*.*",
-                             "methods/*/*.*"]},
     include_package_data=True,
     install_requires=[
         'fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist',
         'esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
-        'StEWI @ git+https://github.com/USEPA/standardizedinventories.git@remote_access#egg=StEWI',
+        'StEWI @ git+https://github.com/USEPA/standardizedinventories.git@develop#egg=StEWI',
         'pandas>=1.3.2',
         'pip>=9',
         'setuptools>=41',


### PR DESCRIPTION
Action: Validate FlowBySectors, downloads the latest generated FBS on the remote server and compares the output to one generated locally at the current `HEAD`. FBS are compared using validation function `compare_FBS_results`. FBS not available on remote are skipped. For stewi based data sources, requires better access to remote in stewi (https://github.com/USEPA/standardizedinventories/pull/101)

Generates an artifact .zip of csv files for review when differences are present.

Error in generating FBS will cause this test to fail. Differences in FBS results do not cause a failure.

Resolves #182 and #184 

Associated updates:
- update pytest.ini to support clearer logging in actions
- ensure all package subfolders are installed using MANIFEST.ini
- add `print_method` parameter to `seeAvailableFlowByModels` to enable skipping of printing of methods
- resolve most FutureWarnings #183 
