### PR TITLE
Support flexibility in mapping files

### DIFF
--- a/flowsa/fbs_allocation.py
+++ b/flowsa/fbs_allocation.py
@@ -273,6 +273,8 @@ def allocation_helper(df_w_sector, attr, method, v, download_FBA_if_missing):
         fba_dict['clean_fba'] = attr['clean_helper_fba']
     if 'clean_helper_fba_wsec' in attr:
         fba_dict['clean_fba_w_sec'] = attr['clean_helper_fba_wsec']
+    if 'helper_activity_to_sector_mapping' in attr:
+        fba_dict['activity_to_sector_mapping'] = attr['helper_activity_to_sector_mapping']
 
     # load the allocation FBA
     helper_allocation = \
@@ -514,10 +516,13 @@ def load_map_clean_fba(method, attr, fba_sourcename, df_year, flowclass,
     fba = fba.reset_index(drop=True)
 
     # assign sector to allocation dataset
+    activity_to_sector_mapping = attr.get('activity_to_sector_mapping')
+    if 'activity_to_sector_mapping' in kwargs:
+        activity_to_sector_mapping = kwargs.get('activity_to_sector_mapping')
     log.info("Adding sectors to %s", fba_sourcename)
     fba_wsec = add_sectors_to_flowbyactivity(fba, sectorsourcename=method[
         'target_sector_source'],
-        activity_to_sector_mapping=attr.get('activity_to_sector_mapping'),
+        activity_to_sector_mapping=activity_to_sector_mapping,
         fbsconfigpath=fbsconfigpath)
 
     # call on fxn to further clean up/disaggregate the fba

--- a/flowsa/fbs_allocation.py
+++ b/flowsa/fbs_allocation.py
@@ -128,7 +128,9 @@ def dataset_allocation_method(flow_subset_mapped, attr, names, method,
     # with activity subset
     log.info("Subsetting %s for sectors in %s", attr['allocation_source'], k)
     fba_allocation_subset = \
-        get_fba_allocation_subset(fba_allocation_wsec, k, names,
+        get_fba_allocation_subset(fba_allocation_wsec,
+                                  v.get('activity_to_sector_mapping', k),
+                                  names,
                                   flowSubsetMapped=flow_subset_mapped,
                                   allocMethod=attr['allocation_method'],
                                   fbsconfigpath=fbsconfigpath)
@@ -161,7 +163,9 @@ def dataset_allocation_method(flow_subset_mapped, attr, names, method,
               (fba_allocation_subset[fba_activity_fields[1]].isin(n_allocated))
               )].reset_index(drop=True)
         fba_allocation_subset_2 = \
-            get_fba_allocation_subset(fba_allocation_subset, k, [n],
+            get_fba_allocation_subset(fba_allocation_subset,
+                                      v.get('activity_to_sector_mapping', k),
+                                      [n],
                                       flowSubsetMapped=flow_subset_mapped,
                                       allocMethod=attr['allocation_method'],
                                       activity_set_names=aset_names,
@@ -272,7 +276,8 @@ def allocation_helper(df_w_sector, attr, method, v, download_FBA_if_missing):
 
     # load the allocation FBA
     helper_allocation = \
-        load_map_clean_fba(method, attr, fba_sourcename=attr['helper_source'],
+        load_map_clean_fba(method, attr,
+                           fba_sourcename=attr['helper_source'],
                            df_year=attr['helper_source_year'],
                            flowclass=attr['helper_source_class'],
                            geoscale_from=attr['helper_from_scale'],

--- a/flowsa/fbs_allocation.py
+++ b/flowsa/fbs_allocation.py
@@ -516,7 +516,9 @@ def load_map_clean_fba(method, attr, fba_sourcename, df_year, flowclass,
     # assign sector to allocation dataset
     log.info("Adding sectors to %s", fba_sourcename)
     fba_wsec = add_sectors_to_flowbyactivity(fba, sectorsourcename=method[
-        'target_sector_source'], fbsconfigpath=fbsconfigpath)
+        'target_sector_source'],
+        activity_to_sector_mapping=attr.get('activity_to_sector_mapping'),
+        fbsconfigpath=fbsconfigpath)
 
     # call on fxn to further clean up/disaggregate the fba
     # allocation data, if exists

--- a/flowsa/flowbysector.py
+++ b/flowsa/flowbysector.py
@@ -265,7 +265,7 @@ def main(**kwargs):
                 # of specified sector aggregation
                 log.info("Adding sectors to %s", k)
                 flows_subset_wsec = add_sectors_to_flowbyactivity(
-                    flows_subset_geo,
+                    flows_subset_geo, v.get('activity_to_sector_mapping'),
                     sectorsourcename=method['target_sector_source'],
                     allocationmethod=attr['allocation_method'],
                     fbsconfigpath=fbsconfigpath)

--- a/flowsa/methods/flowbysectormethods/CAP_HAP_national_2017.yaml
+++ b/flowsa/methods/flowbysectormethods/CAP_HAP_national_2017.yaml
@@ -66,6 +66,7 @@ source_names:
         allocation_from_scale: state
       activity_set_5: &use_allocation # mobile sources and fuel storage
         allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
+        activity_to_sector_mapping: "BEA_2012_Detail"
         allocation_method: proportional
         allocation_source_class: "Money"
         allocation_source_year: 2012
@@ -89,6 +90,7 @@ source_names:
         clean_parameter: {"325310": 'ActivityProducedBy'}
       activity_set_7: # Gross Output
         allocation_source: "BEA_GDP_GrossOutput"
+        activity_to_sector_mapping: "BEA_2012_Detail"
         allocation_method: proportional
         allocation_source_class: "Money"
         allocation_source_year: 2017

--- a/flowsa/methods/flowbysectormethods/CAP_HAP_national_2017.yaml
+++ b/flowsa/methods/flowbysectormethods/CAP_HAP_national_2017.yaml
@@ -7,6 +7,7 @@ source_names:
     class: Chemicals
     geoscale_to_use: state
     year: 2017
+    activity_to_sector_mapping: 'SCC'
     clean_fba_df_fxn: clean_NEI_fba_no_pesticides
     fedefl_mapping: 'NEI'
     activity_set_file: 'NEI_Nonpoint_2017_asets.csv'
@@ -112,6 +113,7 @@ source_names:
     class: Chemicals
     geoscale_to_use: national
     year: 2017
+    activity_to_sector_mapping: 'SCC'
     clean_fba_df_fxn: clean_NEI_fba
     fedefl_mapping: 'NEI'
     activity_set_file: 'NEI_Nonroad_2017_asets.csv'
@@ -128,6 +130,7 @@ source_names:
     class: Chemicals
     geoscale_to_use: national
     year: 2017
+    activity_to_sector_mapping: 'SCC'
     clean_fba_df_fxn: clean_NEI_fba
     fedefl_mapping: 'NEI'
     activity_set_file: 'NEI_Onroad_2017_asets.csv'

--- a/flowsa/methods/flowbysectormethods/README.md
+++ b/flowsa/methods/flowbysectormethods/README.md
@@ -46,37 +46,38 @@ Description of parameters in flowbysectormethods yamls. All values are strings u
 5. _allocation_source_: The primary data source used to allocate main FBA for
    specified activity to sectors
 6. _literature_sources_: (optional)
-7. _allocation_source_class_: specific 'FlowClass' found in the allocation source
+6. _activity_to_sector_mapping_: (optional) name of activity to sector mapping file, if not provided will use the source name
+8. _allocation_source_class_: specific 'FlowClass' found in the allocation source
    flowbyactivity parquet
-8. _allocation_source_year_: specific to the allocation datasets, use the year relevant
+9. _allocation_source_year_: specific to the allocation datasets, use the year relevant
    to the main FBA dataframe
-9. _allocation_flow_: (list) the relevant 'FlowName' values, as found in the source
+10. _allocation_flow_: (list) the relevant 'FlowName' values, as found in the source
    flowbyactivity parquet. Use 'None' to capture all flows.
-10. _allocation_compartment_: (list) the relevant 'Compartment' values, as found in the source
+11. _allocation_compartment_: (list) the relevant 'Compartment' values, as found in the source
    flowbyactivity parquet. Use 'None' to capture all compartments.
-11. _allocation_from_scale_: national, state, or county - dependent on allocation source,
+12. _allocation_from_scale_: national, state, or county - dependent on allocation source,
    as not every level exits for sources
-12. _allocation_fba_load_scale_: (optional) Can indicate geographic level of FBA to load,
+13. _allocation_fba_load_scale_: (optional) Can indicate geographic level of FBA to load,
     helpful when an FBA ia large
-13. _clean_allocation_fba_: (optional) Function to clean up the allocation FBA, as defined in
+14. _clean_allocation_fba_: (optional) Function to clean up the allocation FBA, as defined in
     the source.py file
-14. _clean_allocation_fba_w_sec_: (optional) Function to clean up the allocation FBA, after
+15. _clean_allocation_fba_w_sec_: (optional) Function to clean up the allocation FBA, after
     allocation activities are assigned SectorProducedBy and SectorConsumedBy columns
-15. _allocation_map_to_flow_list_: (optional) If the allocation df and source df need to be matched
+16. _allocation_map_to_flow_list_: (optional) If the allocation df and source df need to be matched
     on Context and/or Flowable, set to 'True'
-16. _helper_source_: (optional) secondary df for sector allocation
-17. _helper_method_: currently written for 'multiplication', 'proportional', and 'proportional-flagged'
-18. _helper_source_class_: specific 'FlowClass' found in the allocation source
+17. _helper_source_: (optional) secondary df for sector allocation
+18. _helper_method_: currently written for 'multiplication', 'proportional', and 'proportional-flagged'
+19. _helper_source_class_: specific 'FlowClass' found in the allocation source
     flowbyactivity parquet
-19. _helper_source_year_: specific to the allocation datasets, use the year relevant
+20. _helper_source_year_: specific to the allocation datasets, use the year relevant
     to the main FBA dataframe
-20. _helper_flow_: (list) the relevant 'FlowName' values, as found in the source
+21. _helper_flow_: (list) the relevant 'FlowName' values, as found in the source
     flowbyactivity parquet
-21. _helper_from_scale_: national, state, or county - dependent on allocation source,
+22. _helper_from_scale_: national, state, or county - dependent on allocation source,
     as not every level exits for sources
-22. _clean_helper_fba_: (optional) Function to clean up the helper FBA, as defined in
+23. _clean_helper_fba_: (optional) Function to clean up the helper FBA, as defined in
     the source.py file
-23. _clean_helper_fba_wsec_: (optional) Function to clean up the helper FBA, after
+24. _clean_helper_fba_wsec_: (optional) Function to clean up the helper FBA, after
     allocation activities are assigned SectorProducedBy and SectorConsumedBy columns
 
 ### Source specifications (in FBS format)

--- a/flowsa/methods/flowbysectormethods/README.md
+++ b/flowsa/methods/flowbysectormethods/README.md
@@ -46,7 +46,7 @@ Description of parameters in flowbysectormethods yamls. All values are strings u
 5. _allocation_source_: The primary data source used to allocate main FBA for
    specified activity to sectors
 6. _literature_sources_: (optional)
-6. _activity_to_sector_mapping_: (optional) name of activity to sector mapping file, if not provided will use the source name
+7. _activity_to_sector_mapping_: (optional) name of activity to sector mapping file, if not provided will use the source name
 8. _allocation_source_class_: specific 'FlowClass' found in the allocation source
    flowbyactivity parquet
 9. _allocation_source_year_: specific to the allocation datasets, use the year relevant
@@ -67,17 +67,18 @@ Description of parameters in flowbysectormethods yamls. All values are strings u
     on Context and/or Flowable, set to 'True'
 17. _helper_source_: (optional) secondary df for sector allocation
 18. _helper_method_: currently written for 'multiplication', 'proportional', and 'proportional-flagged'
-19. _helper_source_class_: specific 'FlowClass' found in the allocation source
+19. _helper_activity_to_sector_mapping_: (optional) name of activity to sector mapping file, if not provided will use the source name
+20. _helper_source_class_: specific 'FlowClass' found in the allocation source
     flowbyactivity parquet
-20. _helper_source_year_: specific to the allocation datasets, use the year relevant
+21. _helper_source_year_: specific to the allocation datasets, use the year relevant
     to the main FBA dataframe
-21. _helper_flow_: (list) the relevant 'FlowName' values, as found in the source
+22. _helper_flow_: (list) the relevant 'FlowName' values, as found in the source
     flowbyactivity parquet
-22. _helper_from_scale_: national, state, or county - dependent on allocation source,
+23. _helper_from_scale_: national, state, or county - dependent on allocation source,
     as not every level exits for sources
-23. _clean_helper_fba_: (optional) Function to clean up the helper FBA, as defined in
+24. _clean_helper_fba_: (optional) Function to clean up the helper FBA, as defined in
     the source.py file
-24. _clean_helper_fba_wsec_: (optional) Function to clean up the helper FBA, after
+25. _clean_helper_fba_wsec_: (optional) Function to clean up the helper FBA, after
     allocation activities are assigned SectorProducedBy and SectorConsumedBy columns
 
 ### Source specifications (in FBS format)

--- a/flowsa/methods/flowbysectormethods/README.md
+++ b/flowsa/methods/flowbysectormethods/README.md
@@ -20,17 +20,18 @@ Description of parameters in flowbysectormethods yamls. All values are strings u
 4. _geoscale_to_use_: the geoscale of the FBA set to use for sector allocation
    (national, state, or county)
 5. _year_: year of available dataset (ex. 2015)
-6. _apply_urban_rural_: Assign flow quantities as urban or rural based on population density by FIPS.
-7. _clean_fba_before_mapping_df_fxn_: (optional) calls on function in the source.py file to clean up/modify
+6. _activity_to_sector_mapping_: (optional) name of activity to sector mapping file, if not provided will use the source name
+7. _apply_urban_rural_: Assign flow quantities as urban or rural based on population density by FIPS.
+8. _clean_fba_before_mapping_df_fxn_: (optional) calls on function in the source.py file to clean up/modify
    the FBA data prior to mapping flows.
-8. _clean_fba_df_fxn_: (optional) calls on function in the source.py file to clean up/modify
+9. _clean_fba_df_fxn_: (optional) calls on function in the source.py file to clean up/modify
    the FBA data prior to allocating data to sectors.
-9. _clean_fba_w_sec_df_fxn_: (optional) calls on function in the source.py file to clean up/modify the
+10. _clean_fba_w_sec_df_fxn_: (optional) calls on function in the source.py file to clean up/modify the
    FBA dataframe, after sector columns are added but prior to allocating data to sectors.
-10. _fedefl_mapping_: (optional) name of mapping file in FEDEFL. If not supplied will use
+11. _fedefl_mapping_: (optional) name of mapping file in FEDEFL. If not supplied will use
    the source_names
-11. _mfl_mapping_: (optional, should not be used if fedefl_mapping is used) name of mapping file for Material Flow List.
-12. _activity_set_file_: (optional) name of mapping file within flowbysectormethods folder
+12. _mfl_mapping_: (optional, should not be used if fedefl_mapping is used) name of mapping file for Material Flow List.
+13. _activity_set_file_: (optional) name of mapping file within flowbysectormethods folder
    which contains list of names for one or more activity_sets. If not supplied
    _names_ should be listed below within each activity set
 

--- a/flowsa/sectormapping.py
+++ b/flowsa/sectormapping.py
@@ -25,8 +25,6 @@ def get_activitytosector_mapping(source, fbsconfigpath=None):
     """
     from flowsa.settings import crosswalkpath
     # first determine activity to sector mapping file name
-    if 'EPA_NEI' in source:
-        source = 'SCC'
     if 'BEA' in source:
         source = 'BEA_2012_Detail'
 

--- a/flowsa/sectormapping.py
+++ b/flowsa/sectormapping.py
@@ -24,10 +24,6 @@ def get_activitytosector_mapping(source, fbsconfigpath=None):
     :return: a pandas df for a standard ActivitytoSector mapping
     """
     from flowsa.settings import crosswalkpath
-    # first determine activity to sector mapping file name
-    if 'BEA' in source:
-        source = 'BEA_2012_Detail'
-
     # identify mapping file name
     mapfn = f'NAICS_Crosswalk_{source}'
 

--- a/flowsa/sectormapping.py
+++ b/flowsa/sectormapping.py
@@ -61,14 +61,15 @@ def get_activitytosector_mapping(source, fbsconfigpath=None):
         return mapping
 
 
-def add_sectors_to_flowbyactivity(
-        flowbyactivity_df, sectorsourcename=SECTOR_SOURCE_NAME,
+def add_sectors_to_flowbyactivity(flowbyactivity_df,
+        activity_to_sector_mapping=None, sectorsourcename=SECTOR_SOURCE_NAME,
         allocationmethod=None, overwrite_sectorlevel=None,
         fbsconfigpath=None):
     """
     Add Sectors from the Activity fields and mapped them to Sector
     from the crosswalk. No allocation is performed.
     :param flowbyactivity_df: A standard flowbyactivity data frame
+    :param activity_to_sector_mapping: str, name for activity_to_sector mapping
     :param sectorsourcename: A sector source name, using package default
     :param allocationmethod: str, modifies function behavoir if = 'direct'
     :param fbsconfigpath, str, optional path to an FBS method outside flowsa repo
@@ -112,6 +113,8 @@ def add_sectors_to_flowbyactivity(
         # if source data activities are text strings, or sector-like
         # activities should be modified, call on the manually
         # created source crosswalks
+        if activity_to_sector_mapping:
+            s = activity_to_sector_mapping
         mapping = get_activitytosector_mapping(s, fbsconfigpath=fbsconfigpath)
         # filter by SectorSourceName of interest
         mapping = mapping[mapping['SectorSourceName'] == sectorsourcename]

--- a/flowsa/sectormapping.py
+++ b/flowsa/sectormapping.py
@@ -39,7 +39,7 @@ def get_activitytosector_mapping(source, fbsconfigpath=None):
             external_mappingpath, mapfn, 'csv')
         if os.path.isfile(f"{external_mappingpath}"
                           f"{activity_mapping_source_name}.csv"):
-            log.info("Loading crosswalk from %s", external_mappingpath)
+            log.info(f"Loading {activity_mapping_source_name}.csv from {external_mappingpath}")
             crosswalkpath = external_mappingpath
     activity_mapping_source_name = get_flowsa_base_name(
         crosswalkpath, mapfn, 'csv')


### PR DESCRIPTION
Adds an optional FBS parameter `activity_to_sector_mapping` to point to alternative mapping files.

Replaces the hard-coded selection for BEA and NEI mapping files.