### PR TITLE
NAICS dictionary for Summary models

### DIFF
--- a/flowsa/methods/flowbysectormethods/BEA_summary_target.yaml
+++ b/flowsa/methods/flowbysectormethods/BEA_summary_target.yaml
@@ -1,3 +1,11 @@
+# This file can be used to set up target NAICS for a summary level model
+# NAICS are targeted to enable 1:1 correspondence between NAICS and BEA
+# Summary sectors
+
+# To use in a FBS method add
+# inherits_from: BEA_summary_target
+# to the top of the method replacing the three parameters below
+
 target_sector_level: NAICS_3
 target_subset_sector_level: {NAICS_4: ['336', '541']}
 # Note 531, 532, 533, and 92* are not resolved at the 3 digit NAICS

--- a/flowsa/methods/flowbysectormethods/BEA_summary_target.yaml
+++ b/flowsa/methods/flowbysectormethods/BEA_summary_target.yaml
@@ -1,0 +1,6 @@
+target_sector_level: NAICS_3
+target_subset_sector_level: {NAICS_4: ['336', '541']}
+# Note 531, 532, 533, and 92* are not resolved at the 3 digit NAICS
+# but they do not resolve at higher resolution and so using 3-digit NAICS
+# is sufficient
+target_sector_source: NAICS_2012_Code

--- a/flowsa/methods/flowbysectormethods/Water_state_2015_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/Water_state_2015_m1.yaml
@@ -1,4 +1,5 @@
-inherits_from: BEA_summary_target
+target_sector_level: NAICS_4
+target_sector_source: NAICS_2012_Code
 target_geoscale: state
 source_names:
   "USGS_NWIS_WU":

--- a/flowsa/methods/flowbysectormethods/Water_state_2015_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/Water_state_2015_m1.yaml
@@ -1,5 +1,4 @@
-target_sector_level: NAICS_4
-target_sector_source: NAICS_2012_Code
+inherits_from: BEA_summary_target
 target_geoscale: state
 source_names:
   "USGS_NWIS_WU":


### PR DESCRIPTION
Add a NAICS dictionary relevant for Summary level models which can be accessed using:
`inherits_from: BEA_Summary_target` in any FBS