### PR TITLE
enable multiple `inherits_from` in fbs method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pandas>=1.3.2                  # Powerful data structures for data analysis, tim
 pip>=9                         # The PyPA recommended tool for installing Python packages.
 setuptools>=41                 # Fully-featured library designed to facilitate packaging Python projects.
 pyyaml>=5.3                    # Yaml for python
+dpath>=2.0.6                   # Dictionary access and manipulation
 requests >=2.22.0              # Web service calls
 appdirs >= 1.4.3               # Storing user data
 pycountry >= 19.8.18           # ISO country codes

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'pip>=9',
         'setuptools>=41',
         'pyyaml>=5.3',
+        'dpath>=2.0.6',
         'requests>=2.22.0',
         'appdirs>=1.4.3',
         'pycountry>=19.8.18',


### PR DESCRIPTION
uses [dpath](https://pypi.org/project/dpath/) for better accessing and manipulating of dictionaries in order to support `inherits_from` at different nodes in FBS method.

For [example](https://github.com/WesIngwersen/GHGbyindustrydocs/commit/b33a3dec3209096ac13d6c66885cebae2d3ad901):
```
inherits_from: BEA_summary_target
target_geoscale: national
source_names:
  inherits_from: GHG_national_2016_m1
```

Using inherits from in an FBS method will update the method from the target identified at that specific node. In the example above, everything within `source_names` from `GHG_national_2016_m1` is added to this method. No further adjustments of this node are possible.

This PR also ensures that inherits_from can use target methods within local directory (first) before looking for the target method in the repo. In the example above prevents the need to have a local version of `BEA_summary_target` when generating FBS outside the repo.

Existing use of `inherits_from` in FBA methods are not impacted.