### PR TITLE
Added custom yaml loader

### DIFF
--- a/flowsa/flowsa_yaml.py
+++ b/flowsa/flowsa_yaml.py
@@ -35,13 +35,19 @@ def include(loader: yaml.Loader, suffix: str, node: yaml.Node) -> dict:
     while keys:
         branch = branch[keys.pop(0)]
 
-    if isinstance(node, yaml.MappingNode) and isinstance(branch, dict):
-        context = loader.construct_mapping(node)
-        branch.update(context)
+    if isinstance(node, yaml.MappingNode):
+        if isinstance(branch, dict):
+            context = loader.construct_mapping(node)
+            branch.update(context)
+        else:
+            raise TypeError(f'{suffix} is not a mapping/dict')
 
-    elif isinstance(node, yaml.SequenceNode) and isinstance(branch, list):
-        context = loader.construct_sequence(node)
-        branch.extend(context)
+    elif isinstance(node, yaml.SequenceNode):
+        if isinstance(branch, list):
+            context = loader.construct_sequence(node)
+            branch.extend(context)
+        else:
+            raise TypeError(f'{suffix} is not a sequence/list')
 
     return branch
 

--- a/flowsa/flowsa_yaml.py
+++ b/flowsa/flowsa_yaml.py
@@ -1,0 +1,54 @@
+from typing import IO
+import yaml
+import flowsa.settings
+from os import path
+
+
+class FlowsaLoader(yaml.SafeLoader):
+    '''
+    Custom YAML loader implementing !include: tag to allow inheriting
+    arbitrary nodes from other yaml files.
+    '''
+    def __init__(self, stream: IO, external_config_path: str = None) -> None:
+        super().__init__(stream)
+        self.add_multi_constructor('!include:', include)
+        self.external_config_path = str(external_config_path)
+
+
+def include(loader: yaml.Loader, suffix: str, node: yaml.Node) -> dict:
+    file, *keys = suffix.split(':')
+
+    for folder in [
+        loader.external_config_path,
+        flowsa.settings.sourceconfigpath,
+        flowsa.settings.flowbysectormethodpath
+    ]:
+        if path.exists(path.join(folder, file)):
+            file = path.join(folder, file)
+            break
+    else:
+        raise FileNotFoundError
+
+    with open(file) as f:
+        branch = yaml.load(f, FlowsaLoader)
+
+    while keys:
+        branch = branch[keys.pop(0)]
+
+    if isinstance(node, yaml.MappingNode) and isinstance(branch, dict):
+        context = loader.construct_mapping(node)
+        branch.update(context)
+
+    elif isinstance(node, yaml.SequenceNode) and isinstance(branch, list):
+        context = loader.construct_sequence(node)
+        branch.extend(context)
+
+    return branch
+
+
+def load(stream, external_config_path: str = None):
+    loader = FlowsaLoader(stream, external_config_path)
+    try:
+        return loader.get_single_data()
+    finally:
+        loader.dispose()

--- a/flowsa/flowsa_yaml.py
+++ b/flowsa/flowsa_yaml.py
@@ -1,4 +1,4 @@
-from typing import IO
+from typing import IO, Any
 import yaml
 import flowsa.settings
 from os import path
@@ -52,7 +52,7 @@ def include(loader: yaml.Loader, suffix: str, node: yaml.Node) -> dict:
     return branch
 
 
-def load(stream, external_config_path: str = None):
+def load(stream: IO, external_config_path: str = None) -> dict:
     loader = FlowsaLoader(stream, external_config_path)
     try:
         return loader.get_single_data()


### PR DESCRIPTION
Added a `flowsa_yaml` module including a custom `yaml` loader called `FlowsaLoader`, and a function `flowsa_yaml.load(stream: IO, external_config_path: str = None)`. The `load` function can be used similarly to the existing `yaml.safe_load()` function, as demonstrated below. The custom loader introduces 2 features:
1. An `!include:<file>:<key>: . . . :<key>` tag is made available for use in our `yaml` method files. A key may be labeled with this tag to include a specific node from a given file. The precise way in which the inclusion occurs depends on the type of node the `!include:` tag is used on: if the tagged node is a scalar node, the included node will be added as the value for the tagged node; if the tagged node is a sequence/list node, the included node (which must also be a sequence/list) will be appended to the beginning of the tagged node's list; and for a mapping/dict node, the included node (which must also be a mapping/dict) will be updated with the key/value pairs from the tagged node (so any matching keys will have the value from the tagged node). If the user attempts to `!include:` a non-mapping node on a mapping node, or a non-sequence node on a sequence node, a `TypeError` will be raised.
2. An `external_config_path` paramter may be supplied to `flowsa_yaml.load()` or the `FlowsaLoader` class. At present, only one may be supplied, and its only use is to specify a folder in addition to flowsa's internal `flowbyactivitymethods/` and `flowbysectormethods/` folders where the `!include:` tag can find a file.

Additionally, this will give us an easy way to implement any other custom tags or other customized handling of `yamls` that may be useful.

Example (supposing we wanted to combine the GHGI sources with NEI onroad data for some reason, but use a custom activity set file for the latter source):

```
source_names: !include:GHG_national_2016_m1.yaml:source_names
  NEI_Onroad: !include:CAP_HAP_national_2017.yaml:source_names:EPA_NEI_Onroad
    activity_set_file: path/to/custom/activity_set_file.csv 
```

This does require refactoring so that `yaml.safe_load()` is replaced in script files with `flowsa_yaml.load()`.

Known issues:
1. I believe `yaml` tags cannot contain spaces, so this implementation won't work with filenames or `yaml` keys that contain spaces. Fortunately, I believe we have generally ensured that filenames and `yaml` keys don't have spaces, but it is something to be aware of.
2. This implementation may not be the best way to handle an external configuration path. In particular, it might be good to have an `!external_config_path:` custom tag to specify such external configuration paths. I believe this would be straightforward to implement.