### PR TITLE
Tweak custom yaml loader

### DIFF
--- a/flowsa/flowsa_yaml.py
+++ b/flowsa/flowsa_yaml.py
@@ -2,6 +2,7 @@ from typing import IO, Any
 import yaml
 import flowsa.settings
 from os import path
+import csv
 
 
 class FlowsaLoader(yaml.SafeLoader):
@@ -12,6 +13,7 @@ class FlowsaLoader(yaml.SafeLoader):
     def __init__(self, stream: IO) -> None:
         super().__init__(stream)
         self.add_multi_constructor('!include:', self.include)
+        self.add_multi_constructor('!from_index:', self.from_index)
         self.add_constructor('!external_config', self.external_config)
         self.external_paths_to_search = []
         self.external_path_to_pass = None
@@ -54,7 +56,10 @@ class FlowsaLoader(yaml.SafeLoader):
         return branch
 
     @staticmethod
-    def external_config(loader: 'FlowsaLoader', node: yaml.Node) -> str:
+    def external_config(
+        loader: 'FlowsaLoader',
+        node: yaml.Node
+    ) -> str or list:
         if isinstance(node, yaml.SequenceNode):
             paths = loader.construct_sequence(node)
             loader.external_paths_to_search.extend(paths)
@@ -65,6 +70,38 @@ class FlowsaLoader(yaml.SafeLoader):
             return path
         else:
             raise TypeError('Cannot tag a mapping node with !external_config')
+
+    @staticmethod
+    def from_index(
+        loader: 'FlowsaLoader',
+        suffix: str,
+        node: yaml.Node
+    ) -> list:
+        file, *keys = suffix.split(':')
+
+        for folder in [
+            *loader.external_paths_to_search,
+            flowsa.settings.flowbysectoractivitysetspath
+        ]:
+            if path.exists(path.join(folder, file)):
+                file = path.join(folder, file)
+                break
+        else:
+            raise FileNotFoundError(f'{file} not found')
+
+        with open(file) as f:
+            index = csv.DictReader(f)
+            name_list = [
+                row['name'] for row in index if row['activity_set'] in keys
+            ]
+
+        if isinstance(node, yaml.SequenceNode):
+            context = loader.construct_sequence(node)
+            name_list.extend(context)
+        elif isinstance(node, yaml.MappingNode):
+            raise TypeError('Cannot tag a mapping node with !from_index:')
+
+        return name_list
 
 
 def load(stream: IO, external_path: str = None) -> dict:


### PR DESCRIPTION
Implements a new custom tag `from_index:<file> <key in .csv index>`, which allows us to get lists of activity set names from a `.csv` file while loading the method `yaml`. This would allow us to remove quite a bit of extraneous code from `flowbysector.py`, and parallel our use of the `!include:` tag.

The `from_index:` tag is currently implemented similarly but not identically to the `!include:` tag. Like the `!include:` tag, a file name is included as part of the tag after the colon. Unlike the `!include:` tag, the key to look up is given as the value of the node in the `yaml` file. This is to allow for spaces in the key, which will in turn allow us to create index files that use more descriptive keys than `activity_set_1`, and which would not need to be updated if we changed the order or designation of activity sets for some reason.

An example is given below:
```
activity_set_1:
  names: !from_index:NEI_Nonpoint_2017_asets.csv activity_set_1
```