### PR TITLE
update pandas requirement to 1.4.0 and Python to >=3.8

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py-version: ['3.7', '3.8', '3.9', '3.10']
+        py-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
 git+https://github.com/USEPA/standardizedinventories.git@develop#egg=StEWI
-pandas>=1.3.2                  # Powerful data structures for data analysis, time series, and statistics.
+pandas>=1.4.0                  # Powerful data structures for data analysis, time series, and statistics.
 pip>=9                         # The PyPA recommended tool for installing Python packages.
 setuptools>=41                 # Fully-featured library designed to facilitate packaging Python projects.
 pyyaml>=5.3                    # Yaml for python

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist',
         'esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
         'StEWI @ git+https://github.com/USEPA/standardizedinventories.git@develop#egg=StEWI',
-        'pandas>=1.3.2',
+        'pandas>=1.4.0',
         'pip>=9',
         'setuptools>=41',
         'pyyaml>=5.3',


### PR DESCRIPTION
- update pandas requirement from 1.3.2 to 1.4.0
- drop support for testing FLOWSA package on Python 3.7
-  addresses issues discussed in Discussion [237](https://github.com/USEPA/flowsa/discussions/237) and Issue [328](https://github.com/USEPA/flowsa/issues/238)