### PR TITLE
Adds display_tables() method to FBS

### DIFF
--- a/flowsa/data_source_scripts/EPA_GHGI.py
+++ b/flowsa/data_source_scripts/EPA_GHGI.py
@@ -680,7 +680,7 @@ def get_manufacturing_energy_ratios(year):
     return pct_dict
 
 
-def allocate_industrial_combustion(fba, source_dict, **_):
+def allocate_industrial_combustion(fba, *_, **__):
     """
     Split industrial combustion emissions into two buckets to be further allocated.
 
@@ -688,7 +688,7 @@ def allocate_industrial_combustion(fba, source_dict, **_):
     EIA MECS relative to EPA GHGI. Create new activities to distinguish those
     which use EIA MECS as allocation source and those that use alternate source.
     """
-    pct_dict = get_manufacturing_energy_ratios(source_dict.get('year'))
+    pct_dict = get_manufacturing_energy_ratios(fba.config.get('year'))
 
     # activities reflect flows in A_14 and 3_8 and 3_9
     activities_to_split = {'Industrial Other Coal Industrial': 'Coal',

--- a/flowsa/methods/flowbysectormethods/SEEA_2017_kg_v1.yaml
+++ b/flowsa/methods/flowbysectormethods/SEEA_2017_kg_v1.yaml
@@ -15,6 +15,23 @@ industry_spec:
 target_naics_year: 2012
 geoscale: national
 
+display_tables:
+  NAICS 2:
+    industry_spec: {default: NAICS_2}
+    replace_dict:
+      Industry: {'31': '31-33', '32': '31-33', '33': '31-33',
+                  '44': '44-45', '45': '44-45',
+                  '48': '48-49', '49': '48-49'},
+      Pollutant: {C2F6: F-GHGs, C3F8: F-GHGs, CF4: F-GHGs,
+                  'HFC, PFC and SF6 F-HTFs': F-GHGs,
+                  HFC-134a: F-GHGs, HFC-23: F-GHGs,
+                  HFCs: F-GHGs, HFCs and PFCs: F-GHGs,
+                  Total F-GHGs: F-GHGs, c-C4F8: F-GHGs,
+                  CO2: Carbon dioxide, CH4: Methane,
+                  N2O: Nitrous oxide, 'N2O[2]': Nitrous oxide,
+                  SF6: Sulfur hexafluoride,
+                  NF3: Nitrogen trifluoride}
+
 _ghgi_parameters: &ghgi_parameters
   geoscale: national
   year: &year 2017
@@ -56,7 +73,6 @@ _attribution_sources:
         - AREA GROWN # Berry totals
         - AREA IN PRODUCTION # Vegetable totals
     year: 2017
-    clean_fba: !script_function:USDA_CoA_Cropland coa_irrigated_cropland_fba_cleanup
     clean_fba_w_sec: !script_function:USDA_CoA_Cropland disaggregate_coa_cropland_to_6_digit_naics
 
 sources_to_cache:

--- a/flowsa/methods/flowbysectormethods/SEEA_2017_v1.yaml
+++ b/flowsa/methods/flowbysectormethods/SEEA_2017_v1.yaml
@@ -15,6 +15,36 @@ industry_spec:
 target_naics_year: 2012
 geoscale: national
 
+display_tables:
+  NAICS 2:
+    industry_spec: {default: NAICS_2}
+    replace_dict:
+      Industry:
+        '31': 31-33
+        '32': 31-33
+        '33': 31-33
+        '44': 44-45
+        '45': 44-45
+        '48': 48-49
+        '49': 48-49
+      Pollutant:
+        C2F6: F-GHGs
+        C3F8: F-GHGs
+        CF4: F-GHGs
+        HFC, PFC and SF6 F-HTFs: F-GHGs
+        HFC-134a: F-GHGs
+        HFC-23: F-GHGs
+        HFCs: F-GHGs
+        HFCs and PFCs: F-GHGs
+        Total F-GHGs: F-GHGs
+        c-C4F8: F-GHGs
+        CO2: Carbon dioxide
+        CH4: Methane
+        N2O: Nitrous oxide
+        N2O[2]: Nitrous oxide
+        SF6: Sulfur hexafluoride
+        NF3: Nitrogen trifluoride
+
 _ghgi_parameters: &ghgi_parameters
   geoscale: national
   year: &year 2017
@@ -55,7 +85,6 @@ _attribution_sources:
         - AREA GROWN # Berry totals
         - AREA IN PRODUCTION # Vegetable totals
     year: 2017
-    clean_fba: !script_function:USDA_CoA_Cropland coa_irrigated_cropland_fba_cleanup
     clean_fba_w_sec: !script_function:USDA_CoA_Cropland disaggregate_coa_cropland_to_6_digit_naics
 
 sources_to_cache:

--- a/flowsa/settings.py
+++ b/flowsa/settings.py
@@ -33,10 +33,12 @@ fbsoutputpath = outputpath + 'FlowBySector/'
 biboutputpath = outputpath + 'Bibliography/'
 logoutputpath = outputpath + 'Log/'
 plotoutputpath = outputpath + 'Plots/'
+tableoutputpath = outputpath + 'DisplayTables/'
 
 # ensure directories exist
 create_paths_if_missing(logoutputpath)
 create_paths_if_missing(plotoutputpath)
+create_paths_if_missing(tableoutputpath)
 
 DEFAULT_DOWNLOAD_IF_MISSING = False
 


### PR DESCRIPTION
This PR adds to `FlowBySector` a `display_tables()` method which generates and saves (as a multi-sheet Excel file) nice display tables, which may be customized (if desired) in the FBS method_yaml, like this:
```
display_tables:
  <Table 1 title>:
    selection_fields:
      # exactly as used elsewhere
    industry_spec:
      # formatted as elsewhere, but can be used to produce a table that is more aggregated than the underlying FBS
    replace_dict:
      <column>:
        <to_replace>: <new_value>
        <to_replace>: <new_value>
        # etc.
```
