### PR TITLE
allow cached datasets to undergo futher selection

### DIFF
--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -1003,11 +1003,22 @@ class FlowByActivity(_FlowBy):
 
         if attribution_method == 'proportional':
             # First check cache for FlowBy
-            if isinstance(fba.config['attribution_source'], str):
-                attribution_fbs = (fba.config['cache']
-                                   [fba.config['attribution_source']])
+            attribution_source = fba.config['attribution_source']
+            if isinstance(attribution_source, str):
+                # attribution_source as string MUST BE cached
+                attribution_fbs = (fba.config['cache'][attribution_source])
             else:
                 (name, config), = fba.config['attribution_source'].items()
+            if name in fba.config['cache'].keys():
+                # cached attribution_source passed as dictionary can include
+                # additional selection fields
+                attribution_fbs = fba.config['cache'][name]
+                if config.get('selection_fields'):
+                    attribution_fbs = (attribution_fbs
+                                       .select_by_fields(
+                                           config.get('selection_fields')
+                                           ))
+            else:
                 attribution_fbs = get_flowby_from_config(
                     name=name,
                     config={**{k: v for k, v in fba.config.items()

--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -1002,22 +1002,21 @@ class FlowByActivity(_FlowBy):
         attribution_method = fba.config.get('attribution_method')
 
         if attribution_method == 'proportional':
-            # First check cache for FlowBy
             attribution_source = fba.config['attribution_source']
+
             if isinstance(attribution_source, str):
-                # attribution_source as string MUST BE cached
-                attribution_fbs = (fba.config['cache'][attribution_source])
+                name, config = attribution_source, {}
             else:
-                (name, config), = fba.config['attribution_source'].items()
-            if name in fba.config['cache'].keys():
-                # cached attribution_source passed as dictionary can include
-                # additional selection fields
-                attribution_fbs = fba.config['cache'][name]
-                if config.get('selection_fields'):
-                    attribution_fbs = (attribution_fbs
-                                       .select_by_fields(
-                                           config.get('selection_fields')
-                                           ))
+                (name, config), = attribution_source.items()
+
+            if name in fba.config['cache']:
+                attribution_fbs = fba.config['cache'][name].copy()
+                attribution_fbs.config = {
+                    **{k: attribution_fbs.config[k]
+                       for k in attribution_fbs.config['method_config_keys']},
+                    **config
+                }
+                attribution_fbs = attribution_fbs.prepare_fbs()
             else:
                 attribution_fbs = get_flowby_from_config(
                     name=name,


### PR DESCRIPTION
Proposal to allow cached datasets to be further filtered for a specific activity set. Should not impact existing methods with cached datasets.

See following simplified example:

```
sources_to_cache:
  EIA_MECS_Energy:
    year: 2014
    selection_fields:
      Class: Energy
      Unit: Trillion Btu
      Description:
          - Table 2.2
          - Table 3.2
    estimate_suppressed: !script_function:temp_data_source_functions estimate_suppressed_mecs_energy
    clean_fba: !script_function:temp_data_source_functions clean_mecs_energy_fba
    clean_fba_w_sec: !script_function:temp_data_source_functions clean_mapped_mecs_energy_fba
    attribution_method: proportional
    attribution_source:
      Employment_national_2018: # replace with 2014 when available
        data_format: FBS
        year: 2018

source_names:
  EPA_NEI_Nonpoint:
    geoscale: state
    year: 2017
    activity_to_sector_mapping: SCC
    fedefl_mapping: NEI
    activity_sets:
      industry_combustion_coal:
        selection_fields:
          PrimaryActivity: !from_index:NEI_Nonpoint_2017_asets.csv industry_combustion_coal
        attribution_method: proportional
        attribution_source:
          EIA_MECS_Energy:
            selection_fields:
              Flowable: Coal
```