### PR TITLE
Refac ghg national

### DIFF
--- a/examples/generate_data_visualization.py
+++ b/examples/generate_data_visualization.py
@@ -87,11 +87,11 @@ dv.generateSankeyDiagram(
 ####### GHG Bar Chart ############
 # Option 1 - GHG emissions by GHG
 dv.stackedBarChart('GHG_national_2018_m1',
-                   sectors_to_include=['111110', '112120', '325312'],
+                   selection_fields={'Sector': ['111110', '112120', '325312']},
                    filename='GHGEmissions')
 
 # Option 2 - specify indicator, much have LCIAformatter installed
 # https://github.com/USEPA/LCIAformatter
 dv.stackedBarChart('GHG_national_2018_m1', impact_cat='Global warming',
-                   sectors_to_include=['111110', '112120', '325312'],
+                   selection_fields={'Sector': ['111110', '112120', '325312']},
                    filename='GHGEmissionsGlobalWarming')

--- a/flowsa/data/VisualizationEssentials.csv
+++ b/flowsa/data/VisualizationEssentials.csv
@@ -1,55 +1,57 @@
-Sector,Color,Abrv_Name
-11,#33A02C,Ag
-115112,#228B22,Land App
-21,#000000,Mining
-22,#696969,Utilities
-2212,#00EEEE,Nat Gas
-221320,#3090C7,Sewer
-23,#C0C0C0,Construction
-236115,#a45a52,Single-Family Housing Const
-236116,#7fffd4,Multifamily Housing Const
-236117,#dd8888,Housing For-Sale Builders
-236118,#657065,Res. Remodelers
-236210,#FF7F00,Industrial Bldg Const
-236220,#7D9EC0,Commercial/Institutional Bldg Const
-237110,#8B0000,Water/Sewer Const
-237130,#71C671,Power/Com. Const
-237310,#4876FF,Road/Bridge Const
-237990,#912CEE,Other Const
-238910,#FF1493,Site Prep
-31,#E31A1C,Mfg - 31
-311111,#C1FFC1,Dog/Cat Food Mfg
-311119,#954535,Animal Feed
-32,#E31A1C,Mfg - 32
-324110,#00688B,Biochem Proc
-327310,#16645f,Concrete Mfg
-33,#E31A1C,Mfg - 33
-42,#1F78B4,Wholesale Trade
-44,#A6CEE3,Retail Trade - 44
-45,#ECC5C0,Retail Trade - 45
-48,#FF6F00,Transp & Whs - 48
-49,#E56717,Transp & Whs - 49
-51,#FDBF6F,Info
-52,#6A3D9A,Finance and Ins
-53,#99C68E,Real Estate
-54,#CAB2D6,Prof and Tech Sev
-55,#583759,Mngmt
-56,#6667AB,Admin & Waste Serv
-5622121,#FFF380,MSW Landfill
-562213,#654A8B,Solid Waste
-5622191,#C88141,Anaerobic Digestion
-5622192,#F67280,Composting
-5629201,#FFA15A,MSW Recycling
-5629202,#91a3b0,Mixed CDD Proc.
-5629203,#9999ff,Concrete Proc.
-61,#800000,Educ
-62,#7E354D,Health Care
-624210,#CCCCFF,Food Bank
-71,#BAB86C,Arts & Rec
-72,#D2691E,Acc & Food Serv
-81,#FF007F,Other Serv
-92,#9F000F,Pub Admin
-F010,#D58A94,Residential
-S00201,#B2DF8A,Gov Loc Psg Transit
-S00101,B5EAAA,Gov Fed Elec Util
-S00202,#98FF98,Gov Loc Elec Util
+Sector,AttributionSource,Color,Abrv_Name
+11,,#33A02C,Ag
+115112,,#228B22,Land App
+21,,#000000,Mining
+22,,#696969,Utilities
+2212,,#00EEEE,Nat Gas
+221320,,#3090C7,Sewer
+23,,#C0C0C0,Construction
+236115,,#a45a52,Single-Family Housing Const
+236116,,#7fffd4,Multifamily Housing Const
+236117,,#dd8888,Housing For-Sale Builders
+236118,,#657065,Res. Remodelers
+236210,,#FF7F00,Industrial Bldg Const
+236220,,#7D9EC0,Commercial/Institutional Bldg Const
+237110,,#8B0000,Water/Sewer Const
+237130,,#71C671,Power/Com. Const
+237310,,#4876FF,Road/Bridge Const
+237990,,#912CEE,Other Const
+238910,,#FF1493,Site Prep
+31,,#E31A1C,Mfg - 31
+311111,,#C1FFC1,Dog/Cat Food Mfg
+311119,,#954535,Animal Feed
+32,,#E31A1C,Mfg - 32
+324110,,#00688B,Biochem Proc
+327310,,#16645f,Concrete Mfg
+33,,#E31A1C,Mfg - 33
+42,,#1F78B4,Wholesale Trade
+44,,#A6CEE3,Retail Trade - 44
+45,,#ECC5C0,Retail Trade - 45
+48,,#FF6F00,Transp & Whs - 48
+49,,#E56717,Transp & Whs - 49
+51,,#FDBF6F,Info
+52,,#6A3D9A,Finance and Ins
+53,,#99C68E,Real Estate
+54,,#CAB2D6,Prof and Tech Sev
+55,,#583759,Mngmt
+56,,#6667AB,Admin & Waste Serv
+5622121,,#FFF380,MSW Landfill
+562213,,#654A8B,Solid Waste
+5622191,,#C88141,Anaerobic Digestion
+5622192,,#F67280,Composting
+5629201,,#FFA15A,MSW Recycling
+5629202,,#91a3b0,Mixed CDD Proc.
+5629203,,#9999ff,Concrete Proc.
+61,,#800000,Educ
+62,,#7E354D,Health Care
+624210,,#CCCCFF,Food Bank
+71,,#BAB86C,Arts & Rec
+72,,#D2691E,Acc & Food Serv
+81,,#FF007F,Other Serv
+92,,#9F000F,Pub Admin
+F010,,#D58A94,Residential
+S00201,,#B2DF8A,Gov Loc Psg Transit
+S00101,,B5EAAA,Gov Fed Elec Util
+S00202,,#98FF98,Gov Loc Elec Util
+,Direct,#4C61AD,Direct
+,Allocated,#6CDF97,Allocated

--- a/flowsa/data/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI.csv
+++ b/flowsa/data/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI.csv
@@ -474,82 +474,79 @@ EPA_GHGI,Electronics Production,NAICS_2012_Code,334413,,334413,EPA_GHGI_T_4_94
 EPA_GHGI,Magnesium Production and Processing,NAICS_2012_Code,331410,,"331410, 331490, 331520",EPA_GHGI_T_4_84
 EPA_GHGI,Magnesium Production and Processing,NAICS_2012_Code,33149,,,EPA_GHGI_T_4_84
 EPA_GHGI,Magnesium Production and Processing,NAICS_2012_Code,33152,,,EPA_GHGI_T_4_84
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,11,,"All sectors, excluding transport",EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,21,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,22,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,23,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,31,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,32,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,33,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,42,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,44,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,45,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,49,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,51,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,52,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,53,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,54,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,55,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,56,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,61,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,62,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,71,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,72,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,81,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,92,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning,NAICS_2012_Code,F01000,,,EPA_GHGI_T_4_101
-EPA_GHGI,Refrigeration/Air Conditioning - Households,NAICS_2012_Code,F01000,,Exclusive household portion,EPA_GHGI_T_4_101
+EPA_GHGI,Industrial Process Refrigeration,NAICS_2012_Code,11,,,EPA_GHGI_T_4_101
+EPA_GHGI,Industrial Process Refrigeration,NAICS_2012_Code,21,,,EPA_GHGI_T_4_101
+EPA_GHGI,Industrial Process Refrigeration,NAICS_2012_Code,2212,,,EPA_GHGI_T_4_101
+EPA_GHGI,Industrial Process Refrigeration,NAICS_2012_Code,23,,,EPA_GHGI_T_4_101
+EPA_GHGI,Industrial Process Refrigeration,NAICS_2012_Code,31,,,EPA_GHGI_T_4_101
+EPA_GHGI,Industrial Process Refrigeration,NAICS_2012_Code,32,,,EPA_GHGI_T_4_101
+EPA_GHGI,Industrial Process Refrigeration,NAICS_2012_Code,33,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,2213,,Apply same mapping as Commercial elsewhere,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,42,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,44,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,45,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,493,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,51,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,52,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,53,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,54,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,55,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,56,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,61,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,62,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,71,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,72,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,81,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,927110,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,923110,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Refrigeration,NAICS_2012_Code,923120,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,2213,,Apply same mapping as Commercial elsewhere,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,42,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,44,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,45,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,493,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,51,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,52,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,53,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,54,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,55,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,56,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,61,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,62,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,71,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,72,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,81,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,927110,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,923110,,,EPA_GHGI_T_4_101
+EPA_GHGI,Commercial Stationary Air Conditioning,NAICS_2012_Code,923120,,,EPA_GHGI_T_4_101
+EPA_GHGI,Domestic Refrigeration,NAICS_2012_Code,F01000,,,EPA_GHGI_T_4_101
+EPA_GHGI,Residential Stationary Air Conditioning,NAICS_2012_Code,F01000,,,EPA_GHGI_T_4_101
 EPA_GHGI,Aerosols,,,,excluded,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,11,,All sectors,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,21,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,22,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,23,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,31,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,32,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,33,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,42,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,44,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,45,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,48,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,49,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,51,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,52,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,53,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,54,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,55,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,56,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,61,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,62,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,71,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,72,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,81,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,92,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Polystyrene,NAICS_2012_Code,F01000,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,11,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,21,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,22,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,23,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,31,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,32,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,33,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,42,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,44,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,45,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,48,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,49,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,51,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,52,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,53,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,54,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,55,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,56,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,61,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,62,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,71,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,72,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,81,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,92,,,EPA_GHGI_T_4_101
-EPA_GHGI,Foams - Urethane,NAICS_2012_Code,F01000,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,11,,All sectors,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,21,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,22,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,23,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,31,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,32,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,33,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,42,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,44,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,45,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,48,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,49,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,51,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,52,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,53,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,54,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,55,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,56,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,61,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,62,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,71,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,72,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,81,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,92,,,EPA_GHGI_T_4_101
+EPA_GHGI,Foams,NAICS_2012_Code,F01000,,,EPA_GHGI_T_4_101
 EPA_GHGI,Solvents,,,,excluded,EPA_GHGI_T_4_101
 EPA_GHGI,Fire Protection,,,,excluded,EPA_GHGI_T_4_101
 EPA_GHGI,Mobile AC - Heavy-Duty Vehicles,NAICS_2012_Code,484,,484000,EPA_GHGI_T_A_103

--- a/flowsa/data/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI.csv
+++ b/flowsa/data/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI.csv
@@ -280,6 +280,9 @@ EPA_GHGI,Coal Commercial,NAICS_2012_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Coal Commercial,NAICS_2012_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Coal Commercial,NAICS_2012_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Coal Commercial,NAICS_2012_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Coal Commercial,NAICS_2012_Code,927110,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Coal Commercial,NAICS_2012_Code,923110,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Coal Commercial,NAICS_2012_Code,923120,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,2213,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,42,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,44,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
@@ -296,6 +299,9 @@ EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_
 EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,927110,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,923110,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Fuel Oil Commercial,NAICS_2012_Code,923120,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,2213,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,42,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,44,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
@@ -312,6 +318,9 @@ EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T
 EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,927110,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,923110,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Natural gas Commercial,NAICS_2012_Code,923120,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Wood Commercial,NAICS_2012_Code,2213,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Wood Commercial,NAICS_2012_Code,42,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Wood Commercial,NAICS_2012_Code,44,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
@@ -328,6 +337,9 @@ EPA_GHGI,Wood Commercial,NAICS_2012_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Wood Commercial,NAICS_2012_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Wood Commercial,NAICS_2012_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Wood Commercial,NAICS_2012_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Wood Commercial,NAICS_2012_Code,927110,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Wood Commercial,NAICS_2012_Code,923110,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI,Wood Commercial,NAICS_2012_Code,923120,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
 EPA_GHGI,Drained Organic Soils Cropland,NAICS_2012_Code,1111,,"111, excl. 1114",EPA_GHGI_T_5_18
 EPA_GHGI,Drained Organic Soils Cropland,NAICS_2012_Code,1112,,,EPA_GHGI_T_5_18
 EPA_GHGI,Drained Organic Soils Cropland,NAICS_2012_Code,1113,,,EPA_GHGI_T_5_18
@@ -357,6 +369,7 @@ EPA_GHGI,Distillate Fuel Oil Transportation,NAICS_2012_Code,491,,,EPA_GHGI_T_A_1
 EPA_GHGI,Distillate Fuel Oil Transportation,NAICS_2012_Code,492,,,EPA_GHGI_T_A_14
 EPA_GHGI,Distillate Fuel Oil Transportation,NAICS_2012_Code,92,,,EPA_GHGI_T_A_14
 EPA_GHGI,Distillate Fuel Oil Transportation,NAICS_2012_Code,F01000,,,EPA_GHGI_T_A_14
+EPA_GHGI,Distillate Fuel Oil Transportation,NAICS_2012_Code,S00201,,,EPA_GHGI_T_A_14
 EPA_GHGI,Jet Fuel Transportation,NAICS_2012_Code,48,,,EPA_GHGI_T_A_14
 EPA_GHGI,Jet Fuel Transportation,NAICS_2012_Code,491,,,EPA_GHGI_T_A_14
 EPA_GHGI,Jet Fuel Transportation,NAICS_2012_Code,492,,,EPA_GHGI_T_A_14
@@ -414,6 +427,9 @@ EPA_GHGI,Commercial Coal Commercial,NAICS_2012_Code,62,,,EPA_GHGI_T_A_14
 EPA_GHGI,Commercial Coal Commercial,NAICS_2012_Code,71,,,EPA_GHGI_T_A_14
 EPA_GHGI,Commercial Coal Commercial,NAICS_2012_Code,72,,,EPA_GHGI_T_A_14
 EPA_GHGI,Commercial Coal Commercial,NAICS_2012_Code,81,,,EPA_GHGI_T_A_14
+EPA_GHGI,Commercial Coal Commercial,NAICS_2012_Code,927110,,S00102,EPA_GHGI_T_A_14
+EPA_GHGI,Commercial Coal Commercial,NAICS_2012_Code,923110,,GSLGE,EPA_GHGI_T_A_14
+EPA_GHGI,Commercial Coal Commercial,NAICS_2012_Code,923120,,GSLGH,EPA_GHGI_T_A_14
 EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,2213,,,EPA_GHGI_T_A_14
 EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,42,,,EPA_GHGI_T_A_14
 EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,44,,,EPA_GHGI_T_A_14
@@ -430,6 +446,9 @@ EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,62,,,EPA_GHGI_T_A_14
 EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,71,,,EPA_GHGI_T_A_14
 EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,72,,,EPA_GHGI_T_A_14
 EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,81,,,EPA_GHGI_T_A_14
+EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,927110,,S00102,EPA_GHGI_T_A_14
+EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,923110,,GSLGE,EPA_GHGI_T_A_14
+EPA_GHGI,Natural Gas Commercial,NAICS_2012_Code,923120,,GSLGH,EPA_GHGI_T_A_14
 EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,2213,,,EPA_GHGI_T_A_14
 EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,42,,,EPA_GHGI_T_A_14
 EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,44,,,EPA_GHGI_T_A_14
@@ -446,6 +465,9 @@ EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,62,,,EPA_GHGI_T_A_14
 EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,71,,,EPA_GHGI_T_A_14
 EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,72,,,EPA_GHGI_T_A_14
 EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,81,,,EPA_GHGI_T_A_14
+EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,927110,,S00102,EPA_GHGI_T_A_14
+EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,923110,,GSLGE,EPA_GHGI_T_A_14
+EPA_GHGI,Total Petroleum Commercial,NAICS_2012_Code,923120,,GSLGH,EPA_GHGI_T_A_14
 EPA_GHGI,Total (All Fuels) Residential,NAICS_2012_Code,F01000,,F0100,EPA_GHGI_T_A_14
 EPA_GHGI,HCFC-22 Production,NAICS_2012_Code,325120,,325120,EPA_GHGI_T_4_50
 EPA_GHGI,Electronics Production,NAICS_2012_Code,334413,,334413,EPA_GHGI_T_4_94
@@ -540,10 +562,10 @@ EPA_GHGI,Comfort Cooling for Trains and Buses - School and Tour Buses,NAICS_2012
 EPA_GHGI,Refrigerated Transport - Ships and Boats,NAICS_2012_Code,483,,483000,EPA_GHGI_T_A_103
 EPA_GHGI,Comfort Cooling for Trains and Buses - Transit Buses,,,,excluded,EPA_GHGI_T_A_103
 EPA_GHGI,Buses,NAICS_2012_Code,485,,485000,EPA_GHGI_T_A_79
-EPA_GHGI,Buses - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,485,,485000,EPA_GHGI_T_A_79
-EPA_GHGI,Buses - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,487,,48A000,EPA_GHGI_T_A_79
-EPA_GHGI,Buses - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,488,,,EPA_GHGI_T_A_79
-EPA_GHGI,Buses - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,S00201,,S00201,EPA_GHGI_T_A_79
+EPA_GHGI,Buses - Distillate Fuel Oil,NAICS_2012_Code,485,,485000,EPA_GHGI_T_A_79
+EPA_GHGI,Buses - Distillate Fuel Oil,NAICS_2012_Code,487,,48A000,EPA_GHGI_T_A_79
+EPA_GHGI,Buses - Distillate Fuel Oil,NAICS_2012_Code,488,,,EPA_GHGI_T_A_79
+EPA_GHGI,Buses - Distillate Fuel Oil,NAICS_2012_Code,S00201,,S00201,EPA_GHGI_T_A_79
 EPA_GHGI,Commercial Aircraft,NAICS_2012_Code,481,,481000,EPA_GHGI_T_A_79
 EPA_GHGI,General Aviation Aircraft,NAICS_2012_Code,481,,481000,EPA_GHGI_T_A_79
 EPA_GHGI,Military Aircraft,NAICS_2012_Code,928110,,S00500,EPA_GHGI_T_A_79
@@ -552,19 +574,21 @@ EPA_GHGI,General Aviation Aircraft Jet Fuel,NAICS_2012_Code,481,,,EPA_GHGI_T_3_1
 EPA_GHGI,General Aviation Aircraft Aviation Gasoline,NAICS_2012_Code,481,,,EPA_GHGI_T_3_13
 EPA_GHGI,Military Aircraft Jet Fuel,NAICS_2012_Code,928110,,,EPA_GHGI_T_3_13
 EPA_GHGI,Light-Duty Trucks,NAICS_2012_Code,F01000,,F01000,EPA_GHGI_T_A_79
+EPA_GHGI,Light-Duty Trucks,NAICS_2012_Code,492,,492000,EPA_GHGI_T_A_79
 EPA_GHGI,Light-Duty Trucks - Gasoline,NAICS_2012_Code,F01000,,F01000,EPA_GHGI_T_A_79
 EPA_GHGI,Light-Duty Trucks - Gasoline,NAICS_2012_Code,492,,492000,EPA_GHGI_T_A_79
 EPA_GHGI,Medium- and Heavy-Duty Trucks,NAICS_2012_Code,484,,484000,EPA_GHGI_T_A_79
-EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,484,,484000,EPA_GHGI_T_A_79
-EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,92212,,S00203,EPA_GHGI_T_A_79
-EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,92214,,,EPA_GHGI_T_A_79
-EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil (Diesel Fuel),NAICS_2012_Code,92216,,,EPA_GHGI_T_A_79
+EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2012_Code,484,,484000,EPA_GHGI_T_A_79
+EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2012_Code,92212,,S00203,EPA_GHGI_T_A_79
+EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2012_Code,92214,,,EPA_GHGI_T_A_79
+EPA_GHGI,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2012_Code,92216,,,EPA_GHGI_T_A_79
 EPA_GHGI,Motorcycles,NAICS_2012_Code,F01000,,F01000,EPA_GHGI_T_A_79
 EPA_GHGI,Passenger Cars,NAICS_2012_Code,F01000,,F01000,EPA_GHGI_T_A_79
+EPA_GHGI,Passenger Cars,NAICS_2012_Code,922,,"S00600, GSLGO",EPA_GHGI_T_A_79
+EPA_GHGI,Passenger Cars,NAICS_2012_Code,491,,491000,EPA_GHGI_T_A_79
 EPA_GHGI,Passenger Cars - Gasoline,NAICS_2012_Code,F01000,,F01000,EPA_GHGI_T_A_79
-EPA_GHGI,Passenger Cars - Gasoline,NAICS_2012_Code,92,,S00600,EPA_GHGI_T_A_79
+EPA_GHGI,Passenger Cars - Gasoline,NAICS_2012_Code,922,,"S00600, GSLGO",EPA_GHGI_T_A_79
 EPA_GHGI,Passenger Cars - Gasoline,NAICS_2012_Code,491,,491000,EPA_GHGI_T_A_79
-EPA_GHGI,Passenger Cars - Gasoline,NAICS_2012_Code,92,,GSLGO,EPA_GHGI_T_A_79
 EPA_GHGI,Pipelines,NAICS_2012_Code,486,,486000,EPA_GHGI_T_A_79
 EPA_GHGI,Pipeline Natural Gas,NAICS_2012_Code,486,,,EPA_GHGI_T_3_13
 EPA_GHGI,Rail,NAICS_2012_Code,482,,482000,EPA_GHGI_T_A_79

--- a/flowsa/data_source_scripts/BEA.py
+++ b/flowsa/data_source_scripts/BEA.py
@@ -213,10 +213,13 @@ def subset_and_equally_allocate_BEA_table(df, attr, **_):
 
     # equally attribute bea codes to each mapped sector
     groupby_cols = ['group_id']
+    c = 'Produced'
+    if df[f'Activity{c}By'].isnull().values.all():
+        col = 'Consumed'
     df2 = (
         df
         .assign(
-            **{f'_naics_{n}': df['SectorConsumedBy'].str.slice(stop=n)
+            **{f'_naics_{n}': df[f'Sector{c}By'].str.slice(stop=n)
                for n in range(2, 7)},
             **{f'_unique_naics_{n}_by_group': lambda x, i=n: (
                 x.groupby(groupby_cols if i == 2
@@ -233,10 +236,10 @@ def subset_and_equally_allocate_BEA_table(df, attr, **_):
             )
         )
     )
-    groupby_cols.append('SectorConsumedBy')
+    groupby_cols.append(f'Sector{c}By')
 
     # replace ACB
-    df2['ActivityConsumedBy'] = df2['SectorConsumedBy']
+    df2[f'Activity{c}By'] = df2[f'Sector{c}By']
 
     df2 = df2.drop(
         columns=['group_id', *[f'_naics_{n}' for n in range(2, 7)],

--- a/flowsa/data_source_scripts/EIA_MECS.py
+++ b/flowsa/data_source_scripts/EIA_MECS.py
@@ -7,16 +7,17 @@ MANUFACTURING ENERGY CONSUMPTION SURVEY (MECS)
 https://www.eia.gov/consumption/manufacturing/data/2014/
 Last updated: 8 Sept. 2020
 """
-
+from functools import reduce
 import io
 import math
 
 import pandas as pd
 import numpy as np
+from flowsa.allocation import equally_allocate_parent_to_child_naics
 from flowsa.location import US_FIPS
-from flowsa.common import WITHDRAWN_KEYWORD
+from flowsa.common import WITHDRAWN_KEYWORD, load_crosswalk
 from flowsa.settings import vLogDetailed
-from flowsa.flowbyfunctions import assign_fips_location_system
+from flowsa.flowbyfunctions import assign_fips_location_system, sector_aggregation
 from flowsa.dataclean import replace_strings_with_NoneType, \
     replace_NoneType_with_empty_cells
 from flowsa.data_source_scripts.EIA_CBECS_Land import \
@@ -497,6 +498,131 @@ def eia_mecs_energy_clean_allocation_fba_w_sec(
     df2 = df[df['FlowAmount'] != 0].reset_index(drop=True)
 
     return df2
+
+def mecs_energy_equally_attribute(
+        df_w_sec, attr, method, **kwargs):
+    """
+    This function equally attributes EIA MECS data to NAICS6. This function
+    was developed by pulling from existing functions in the recursive_refac
+    branch: clean_mecs_energy_fba(), clean_mapped_mecs_energy_fba(),
+    and equally_attribute().
+
+    :param df_w_sec: df, EIA MECS Energy, FBA format with sector columns
+    :param attr: dictionary, attribute data from method yaml for activity set
+    :param method: dictionary, FBS method yaml
+    :param kwargs: includes "sourcename" which is required for other
+        'clean_fba_w_sec' fxns
+    :return: df, EIA MECS energy with estimated missing data
+    """
+
+    # drop rows where flowamount = 0, which drops supressed data
+    df = df_w_sec[df_w_sec['FlowAmount'] != 0].reset_index(drop=True)
+
+    mecs = (
+        df
+        .assign(descendants='')
+        .assign(group_id=df.reset_index().index)
+    )
+
+    for level in [5, 4, 3]:
+        descendants = (
+            mecs
+            .drop(columns='descendants')
+            .query(f'ActivityConsumedBy.str.len() > {level}')
+            .assign(
+                parent=lambda x: x.ActivityConsumedBy.str.slice(stop=level)
+            )
+            .groupby(['FlowName', 'Location', 'parent'])
+            .agg({'FlowAmount': 'sum', 'ActivityConsumedBy': ' '.join})
+            .reset_index()
+            .rename(columns={'ActivityConsumedBy': 'descendants',
+                             'FlowAmount': 'descendant_flows',
+                             'parent': 'ActivityConsumedBy'})
+        )
+
+        mecs = (
+            mecs
+            .merge(descendants,
+                   how='left',
+                   on=['FlowName', 'Location', 'ActivityConsumedBy'],
+                   suffixes=(None, '_y'))
+            .fillna({'descendant_flows': 0, 'descendants_y': ''})
+            .assign(
+                descendants=lambda x: x.descendants.mask(x.descendants == '',
+                                                         x.descendants_y),
+                FlowAmount=lambda x: (x.FlowAmount - x.descendant_flows).mask(
+                    x.FlowAmount - x.descendant_flows < 0, 0)
+            )
+            .drop(columns=['descendant_flows', 'descendants_y'])
+        )
+
+    # drop sector columns and map all data to NAICS6
+    # load naics 2 to naics 6 crosswalk
+    cw_load = load_crosswalk('sector_length')
+    # only keep official naics
+    cw = cw_load.drop(columns=['NAICS_7']).drop_duplicates()
+    cw_melt = pd.melt(cw,
+                      id_vars=["NAICS_6"], var_name="NAICS_Length",
+                      value_name="Activity").drop(
+        columns=['NAICS_Length']).drop_duplicates()
+
+    mecs2 = mecs.drop(columns=['SectorConsumedBy'])
+    mecs2 = (mecs2
+             .merge(cw_melt, how='left', left_on='ActivityConsumedBy',
+                        right_on='Activity')
+             .rename(columns={'NAICS_6': 'SectorConsumedBy'})
+             .drop(columns=['Activity'])
+             )
+    mecs2['SectorConsumedBy'] = mecs2['SectorConsumedBy'].fillna(
+        mecs2['ActivityConsumedBy'])
+
+    mecs_sub = (
+        mecs2
+        .assign(to_keep=mecs2.apply(
+            lambda x: not any([x.SectorConsumedBy.startswith(d)
+                               for d in x.descendants.split()]),
+            axis='columns'
+        ))
+        .query('to_keep')
+        .drop(columns=['descendants', 'to_keep'])
+    )
+
+    groupby_cols = ['group_id']
+    mecs_sub = (
+        mecs_sub
+        .assign(
+            **{f'_naics_{n}': mecs_sub['SectorConsumedBy'].str.slice(stop=n)
+               for n in range(2, 7)},
+            **{f'_unique_naics_{n}_by_group': lambda x, i=n: (
+                x.groupby(groupby_cols if i == 2
+                          else [*groupby_cols, f'_naics_{i - 1}'],
+                          dropna=False)
+                [[f'_naics_{i}']]
+                .transform('nunique', dropna=False)
+            )
+               for n in range(2, 7)},
+            FlowAmount=lambda x: reduce(
+                lambda x, y: x / y,
+                [x.FlowAmount, *[x[f'_unique_naics_{n}_by_group']
+                                 for n in range(2, 7)]]
+            )
+        )
+    )
+    groupby_cols.append('SectorConsumedBy')
+
+    # replace ACB
+    mecs_sub['ActivityConsumedBy'] = mecs_sub['SectorConsumedBy']
+
+    mecs_sub = mecs_sub.drop(
+        columns=['group_id', *[f'_naics_{n}' for n in range(2, 7)],
+                 *[f'_unique_naics_{n}_by_group' for n in range(2, 7)]]
+    )
+    # aggregate
+    mecs_sub2 = sector_aggregation(mecs_sub)
+    mecs_sub2 = mecs_sub2[mecs_sub2['FlowAmount'] != 0].sort_values(
+        'SectorConsumedBy').reset_index(drop=True)
+
+    return mecs_sub
 
 
 def mecs_land_fba_cleanup(fba, **_):

--- a/flowsa/data_source_scripts/EIA_MECS.py
+++ b/flowsa/data_source_scripts/EIA_MECS.py
@@ -622,7 +622,7 @@ def mecs_energy_equally_attribute(
     mecs_sub2 = mecs_sub2[mecs_sub2['FlowAmount'] != 0].sort_values(
         'SectorConsumedBy').reset_index(drop=True)
 
-    return mecs_sub
+    return mecs_sub2
 
 
 def mecs_land_fba_cleanup(fba, **_):
@@ -704,6 +704,9 @@ def determine_flows_requiring_disaggregation(
 
     from flowsa.sectormapping import add_sectors_to_flowbyactivity
 
+    # drop group_id, which are used in some clean_fba_w_sec fnxs
+    df_load = df_load.drop(columns=['group_id'], errors='ignore')
+
     df_load = replace_NoneType_with_empty_cells(df_load)
     # drop rows where there is no value in sector column, which might occur if
     # sector-like activities have a "-" in them
@@ -717,7 +720,7 @@ def determine_flows_requiring_disaggregation(
 
     # original df - subset
     # subset cols of original df
-    dfo = df_load[['FlowAmount', 'Location', sector_column]]
+    dfo = df_load[['FlowName', 'FlowAmount', 'Location', sector_column]]
     # min and max length
     min_length = min(df_load[sector_column].apply(
         lambda x: len(str(x))).unique())
@@ -744,9 +747,10 @@ def determine_flows_requiring_disaggregation(
         df2 = df2.rename(
             columns={'FlowAmount': 'SubtractFlow', sector_column: 'Sector'})
         df_m = pd.merge(
-            vars()[df_name_1][['FlowAmount', 'Location', sector_column]],
-            df2, left_on=['Location', sector_column],
-            right_on=['Location', 'SectorMatch'],
+            vars()[df_name_1][['FlowName', 'FlowAmount', 'Location',
+                               sector_column]],
+            df2, left_on=['FlowName', 'Location', sector_column],
+            right_on=['FlowName', 'Location', 'SectorMatch'],
             indicator=True, how='outer')
         # subset by merge and append to appropriate df
         df_both = df_m[df_m['_merge'] == 'both']
@@ -756,7 +760,7 @@ def determine_flows_requiring_disaggregation(
                 columns=['Sector', 'SectorMatch', '_merge'])
             # aggregate before subtracting
             df_both2 = df_both1.groupby(
-                ['FlowAmount', 'Location', sector_column],
+                ['FlowName', 'FlowAmount', 'Location', sector_column],
                 as_index=False).agg({"SubtractFlow": sum})
             df_both3 = df_both2.assign(
                 FlowAmount=df_both2['FlowAmount'] - df_both2['SubtractFlow'])
@@ -774,7 +778,7 @@ def determine_flows_requiring_disaggregation(
             df_right = df_right.assign(SectorMatch=df_right[
                 sector_column].apply(lambda x: x[:(s - 2)]))
             # reorder
-            df_right = df_right[['FlowAmount', 'Location',
+            df_right = df_right[['FlowName', 'FlowAmount', 'Location',
                                  sector_column, 'SectorMatch']]
             df_not_merged = pd.concat([df_not_merged, df_right],
                                       ignore_index=True)
@@ -802,9 +806,9 @@ def determine_flows_requiring_disaggregation(
         [activity_column, sector_column]).reset_index(drop=True)
     # drop the sectors that are duplicated by different naics being
     # mapped to naics6
-    if len(dfn2[dfn2.duplicated(subset=['Location', sector_column],
+    if len(dfn2[dfn2.duplicated(subset=['FlowName', 'Location', sector_column],
                                 keep=False)]) > 0:
-        dfn2.drop_duplicates(subset=['Location', sector_column],
+        dfn2.drop_duplicates(subset=['FlowName', 'Location', sector_column],
                              keep='last', inplace=True)
     # want to allocate at NAICS6, so drop all other sectors
     dfn2 = \

--- a/flowsa/datavisualization.py
+++ b/flowsa/datavisualization.py
@@ -434,11 +434,6 @@ def generateSankeyData(methodname,
     if sectors_to_include is not None:
         df = df[df['Sector'].str.startswith(tuple(sectors_to_include))]
 
-    # aggregate/subset to specified sectors to display
-    df = aggregate_FBS_sectors_for_datavis(df, methodname, target_sector_level,
-                                           target_subset_sector_level,
-                                           fbsconfigpath)
-
     method_dict = load_yaml_dict(methodname, flowbytype='FBS',
                                  filepath=fbsconfigpath)
 

--- a/flowsa/datavisualization.py
+++ b/flowsa/datavisualization.py
@@ -272,8 +272,14 @@ def stackedBarChart(df,
 
     # create list of n colors based on number of allocation sources
     colors = df2[[stacking_col]].drop_duplicates()
-    colors['Color'] = colors.apply(
-        lambda row: "#%06x" % random.randint(0, 0xFFFFFF), axis=1)
+    # add colors
+    vis = pd.read_csv(f'{datapath}VisualizationEssentials.csv').rename(
+        columns={'AttributionSource': stacking_col})
+    colors = colors.merge(vis[[stacking_col, 'Color']], how='left')
+
+    # fill in any colors missing from the color dictionary with random colors
+    colors['Color'] = colors['Color'].apply(lambda x: x if pd.notnull(x) else
+    "#%06x" % random.randint(0, 0xFFFFFF))
     # merge back into df
     df2 = df2.merge(colors, how='left')
 

--- a/flowsa/fbs_allocation.py
+++ b/flowsa/fbs_allocation.py
@@ -619,6 +619,8 @@ def load_map_clean_fba(method, attr, fba_sourcename, df_year, flowclass,
         fba2,
         sectorsourcename=method['target_sector_source'],
         activity_to_sector_mapping=activity_to_sector_mapping,
+        overwrite_sectorlevel=attr.get(
+            'activity_to_sector_aggregation_level'),
         fbsconfigpath=fbsconfigpath
     )
 

--- a/flowsa/fbs_allocation.py
+++ b/flowsa/fbs_allocation.py
@@ -417,15 +417,17 @@ def allocation_helper(df_w_sector, attr, method, v, download_FBA_if_missing):
         # load bea codes that sub for naics
         bea = return_bea_codes_used_as_naics()
         # replace sector column and helperflow value if the sector column to
-        # merge is in the bea list to prevent dropped data
-        modified_fba_allocation['Sector'] = \
-            np.where(modified_fba_allocation[sector_col_to_merge].isin(bea),
-                     modified_fba_allocation[sector_col_to_merge],
-                     modified_fba_allocation['Sector'])
-        modified_fba_allocation['HelperFlow'] = \
-            np.where(modified_fba_allocation[sector_col_to_merge].isin(bea),
-                     modified_fba_allocation['FlowAmount'],
-                     modified_fba_allocation['HelperFlow'])
+        # merge is in the bea list to prevent dropped data,
+        # unless these bea codes already are in the helper dataframe, then skip
+        if not modified_fba_allocation['Sector'].isin(bea).any():
+            modified_fba_allocation['Sector'] = \
+                np.where(modified_fba_allocation[sector_col_to_merge].isin(bea),
+                         modified_fba_allocation[sector_col_to_merge],
+                         modified_fba_allocation['Sector'])
+            modified_fba_allocation['HelperFlow'] = \
+                np.where(modified_fba_allocation[sector_col_to_merge].isin(bea),
+                         modified_fba_allocation['FlowAmount'],
+                         modified_fba_allocation['HelperFlow'])
 
     # modify flow amounts using helper data
     if 'multiplication' in attr['helper_method']:
@@ -483,6 +485,9 @@ def allocation_helper(df_w_sector, attr, method, v, download_FBA_if_missing):
         modified_fba_allocation = modified_fba_allocation.assign(
             FlowAmountRatio=modified_fba_allocation['HelperFlow'] /
                             modified_fba_allocation['Denominator'])
+        # where disagg flag is 0, ensure flowamountratio is 1
+        modified_fba_allocation['FlowAmountRatio'] = \
+            modified_fba_allocation['FlowAmountRatio'].fillna(0)
         modified_fba_allocation =\
             modified_fba_allocation.assign(
                 FlowAmount=modified_fba_allocation['FlowAmount'] *
@@ -491,14 +496,13 @@ def allocation_helper(df_w_sector, attr, method, v, download_FBA_if_missing):
             modified_fba_allocation.drop(
                 columns=['disaggregate_flag', 'Sector', 'HelperFlow',
                          'Denominator', 'FlowAmountRatio'])
-        # run sector aggregation
-        modified_fba_allocation = \
-            sector_aggregation(modified_fba_allocation)
 
     # drop rows of 0
-    modified_fba_allocation =\
-        modified_fba_allocation[
+    modified_fba_allocation = modified_fba_allocation[
             modified_fba_allocation['FlowAmount'] != 0].reset_index(drop=True)
+
+    # run sector aggregation
+    modified_fba_allocation = sector_aggregation(modified_fba_allocation)
 
     modified_fba_allocation.loc[
         modified_fba_allocation['Unit'] == 'gal/employee', 'Unit'] = 'gal'
@@ -636,5 +640,8 @@ def load_map_clean_fba(method, attr, fba_sourcename, df_year, flowclass,
             sourcename=fba_sourcename,
             download_FBA_if_missing=kwargs['download_FBA_if_missing']
         )
+
+    # drop group_id, which are used in some clean_fba_w_sec fnxs
+    fba_wsec = fba_wsec.drop(columns=['group_id'], errors='ignore')
 
     return fba_wsec

--- a/flowsa/fbs_allocation.py
+++ b/flowsa/fbs_allocation.py
@@ -604,6 +604,7 @@ def load_map_clean_fba(method, attr, fba_sourcename, df_year, flowclass,
         )
     # reset index
     fba2 = fba2.reset_index(drop=True)
+    fba2 = fba2.assign(group_id=fba2.reset_index().index.astype(str))
 
     if len(fba2) == 0:
         raise flowsa.exceptions.FBSMethodConstructionError(

--- a/flowsa/flowbyfunctions.py
+++ b/flowsa/flowbyfunctions.py
@@ -228,20 +228,24 @@ def sector_aggregation(df_load, return_all_possible_sector_combos=False,
 
     # determine grouping columns - based on datatype
     group_cols = list(df.select_dtypes(include=['object', 'int']).columns)
-    # determine if activities are sector-like, if aggregating a df with a
-    # 'SourceName'
-    sector_like_activities = check_activities_sector_like(df_load)
+    sector_cols = ['SectorProducedBy', 'SectorConsumedBy']
+    if 'Sector' in df.columns:
+        sector_cols = ['Sector']
 
-    # if activities are sector like, drop columns while running ag then
-    # add back in
-    if sector_like_activities:
-        # subset df
-        df_cols = [e for e in df.columns if e not in
-                   ('ActivityProducedBy', 'ActivityConsumedBy')]
-        group_cols = [e for e in group_cols if e not in
-                      ('ActivityProducedBy', 'ActivityConsumedBy')]
-        df = df[df_cols]
-        df = df.reset_index(drop=True)
+    if 'ActivityProducedBy' in df.columns:
+        # determine if activities are sector-like, if aggregating a df with a
+        # 'SourceName'
+        sector_like_activities = check_activities_sector_like(df_load)
+        # if activities are sector like, drop columns while running ag then
+        # add back in
+        if sector_like_activities:
+            # subset df
+            df_cols = [e for e in df.columns if e not in
+                       ('ActivityProducedBy', 'ActivityConsumedBy')]
+            group_cols = [e for e in group_cols if e not in
+                          ('ActivityProducedBy', 'ActivityConsumedBy')]
+            df = df[df_cols]
+            df = df.reset_index(drop=True)
 
     # load naics length crosswwalk
     cw_load = load_crosswalk('sector_length')
@@ -252,21 +256,20 @@ def sector_aggregation(df_load, return_all_possible_sector_combos=False,
         # sectorconsumedby otherwise single cr
         if isinstance(sectors_to_exclude_from_agg, dict):
             cws = {}
-            for s in ['Produced', 'Consumed']:
+            for s in sector_cols:
                 try:
                     cw = remove_parent_sectors_from_crosswalk(
-                        cw_load, sectors_to_exclude_from_agg[f'Sector{s}By'])
-                    cws[f'Sector{s}By'] = cw
+                        cw_load, sectors_to_exclude_from_agg[s])
+                    cws[s] = cw
                 except KeyError:
-                    cws[f'Sector{s}By'] = cw_load
+                    cws[s] = cw_load
             cw_load = cws.copy()
         else:
             cw_load = remove_parent_sectors_from_crosswalk(
                 cw_load, sectors_to_exclude_from_agg)
 
     # find the longest length sector
-    length = df[[fbs_activity_fields[0], fbs_activity_fields[1]]].apply(
-        lambda x: x.str.len()).max().max()
+    length = df[sector_cols].apply(lambda x: x.str.len()).max().max()
     length = int(length)
     # for loop in reverse order longest length NAICS minus 1 to 2
     # appends missing naics levels to df
@@ -277,12 +280,13 @@ def sector_aggregation(df_load, return_all_possible_sector_combos=False,
         else:
             df = append_new_sectors(df, i, 1, cw_load, group_cols)
 
-    # if activities are source-like, set col values as
-    # copies of the sector columns
-    if sector_like_activities & ('FlowAmount' in df.columns) & \
-            ('ActivityProducedBy' in df_load.columns):
-        df = df.assign(ActivityProducedBy=df['SectorProducedBy'])
-        df = df.assign(ActivityConsumedBy=df['SectorConsumedBy'])
+    if 'ActivityProducedBy' in df.columns:
+        # if activities are source-like, set col values as
+        # copies of the sector columns
+        if sector_like_activities & ('FlowAmount' in df.columns) & \
+                ('ActivityProducedBy' in df_load.columns):
+            df = df.assign(ActivityProducedBy=df['SectorProducedBy'])
+            df = df.assign(ActivityConsumedBy=df['SectorConsumedBy'])
 
     # replace null values
     df = replace_strings_with_NoneType(df).reset_index(drop=True)
@@ -309,31 +313,38 @@ def append_new_sectors(df, i, j, cw_load, group_cols):
     sector_add = 'NAICS_' + str(i - j)
 
     cw_dict = {}
-    if isinstance(cw_load, dict):
-        for s in ['Produced', 'Consumed']:
-            cw = cw_load[f'Sector{s}By'][[sector_merge,
-                                          sector_add]].drop_duplicates()
-            cw_dict[s] = cw
+    if 'Sector' in df.columns:
+        cw_dict['Sector'] = cw_load[
+            [sector_merge, sector_add]].drop_duplicates()
     else:
-        cw_dict['Produced'] = cw_load[
-            [sector_merge, sector_add]].drop_duplicates()
-        cw_dict['Consumed'] = cw_load[
-            [sector_merge, sector_add]].drop_duplicates()
+        if isinstance(cw_load, dict):
+            for s in ['Produced', 'Consumed']:
+                cw = cw_load[f'Sector{s}By'][[sector_merge,
+                                              sector_add]].drop_duplicates()
+                cw_dict[s] = cw
+        else:
+            cw_dict['SectorProducedBy'] = cw_load[
+                [sector_merge, sector_add]].drop_duplicates()
+            cw_dict['SectorConsumedBy'] = cw_load[
+                [sector_merge, sector_add]].drop_duplicates()
 
     cw_melt = load_sector_length_cw_melt()
     cw_sub = cw_melt[cw_melt['SectorLength'] == i]
     sector_list = cw_sub['Sector'].drop_duplicates().values.tolist()
 
     # loop through and add additional sectors
-    sectype_list = ['Produced', 'Consumed']
+    if 'Sector' in df.columns:
+        sectype_list = ['Sector']
+    else:
+        sectype_list = ['SectorProducedBy', 'SectorConsumedBy']
     for s in sectype_list:
-        dfm = df[df[f'Sector{s}By'].isin(sector_list)]
-        dfm = dfm.merge(cw_dict[s], how='left', left_on=[f'Sector{s}By'],
+        dfm = df[df[s].isin(sector_list)]
+        dfm = dfm.merge(cw_dict[s], how='left', left_on=[s],
                         right_on=sector_merge)
         # replace sector column with matched sector add
-        dfm[f'Sector{s}By'] = np.where(
+        dfm[s] = np.where(
             ~dfm[sector_add].isnull(), dfm[sector_add],
-            dfm[f'Sector{s}By'])
+            dfm[s])
         dfm = dfm.drop(columns=[sector_merge, sector_add])
         dfm = replace_NoneType_with_empty_cells(dfm)
 
@@ -349,8 +360,8 @@ def append_new_sectors(df, i, j, cw_load, group_cols):
         agg_sectors = replace_NoneType_with_empty_cells(agg_sectors)
         cols = [e for e in df.columns if e in
                 ['FlowName', 'Flowable', 'Class', 'SectorProducedBy',
-                 'SectorConsumedBy', 'Compartment', 'Context', 'Location',
-                 'Unit', 'FlowType', 'Year']]
+                 'SectorConsumedBy', 'Sector', 'Compartment', 'Context',
+                 'Location', 'Unit', 'FlowType', 'Year']]
         # get copies where the indices are the columns of interest
         df_2 = df.set_index(cols)
         agg_sectors_2 = agg_sectors.set_index(cols)

--- a/flowsa/flowbyfunctions.py
+++ b/flowsa/flowbyfunctions.py
@@ -232,7 +232,7 @@ def sector_aggregation(df_load, return_all_possible_sector_combos=False,
     if 'Sector' in df.columns:
         sector_cols = ['Sector']
 
-    if 'ActivityProducedBy' in df.columns:
+    if 'ActivityProducedBy' in df_load.columns:
         # determine if activities are sector-like, if aggregating a df with a
         # 'SourceName'
         sector_like_activities = check_activities_sector_like(df_load)
@@ -280,7 +280,7 @@ def sector_aggregation(df_load, return_all_possible_sector_combos=False,
         else:
             df = append_new_sectors(df, i, 1, cw_load, group_cols)
 
-    if 'ActivityProducedBy' in df.columns:
+    if 'ActivityProducedBy' in df_load.columns:
         # if activities are source-like, set col values as
         # copies of the sector columns
         if sector_like_activities & ('FlowAmount' in df.columns) & \

--- a/flowsa/methods/flowbysectormethods/GHG_national_2016_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2016_m1.yaml
@@ -75,16 +75,16 @@ source_names:
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
   "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
         allocation_source_year: &mecs_year 2018
         helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
         helper_source_year: *mecs_year
 

--- a/flowsa/methods/flowbysectormethods/GHG_national_2016_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2016_m1.yaml
@@ -5,10 +5,18 @@
 # CoA year is 2017
 
 !include:GHG_national_m1.yaml
+ghgi_year: &ghgi_year 2016
+mecs_year: &mecs_year 2018
+
+_industrial_allocation_dict: &industrial_dict
+    energy_fba: 'EIA_MECS_Energy'
+    year: *mecs_year
+    ghg_fba: 'EPA_GHGI_T_A_7' # 2018 Table
+
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
-    year: &ghgi_year 2016
+    year: *ghgi_year
     activity_sets: # Update USGS year for these activity_sets
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
@@ -81,32 +89,28 @@ source_names:
       !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
-        allocation_source_year: &mecs_year 2018
-        helper_source_year: *mecs_year
+        allocation_source_year: *mecs_year
       natural_gas:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
-## Major CO2 Sources
+### Major CO2 Sources
   "EPA_GHGI_T_A_9":  # CO2 emissions from stationary combustion and transportation. This table number changes with year
     !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets: # Update EIA_MECS year for some activity_sets
       !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        helper_source_year: *ghgi_year
       aviation_transport:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
@@ -129,28 +133,25 @@ source_names:
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-

--- a/flowsa/methods/flowbysectormethods/GHG_national_2016_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2016_m1.yaml
@@ -1,690 +1,156 @@
-# m1 for the GHG national replicates the method used in the National GHG
-# Industry Attribution Model (https://doi.org/10.23719/1517571), except that
-# sector attribution is to 6-digit NAICS, rather than the BEA 2012 IO schema
+# This is a 2016 target year specific implementation of GHG_national_m1
+# All parameters add year specific data when needed to implement for 2016
+# GHGI FBA table names match the 2022 GHGI Report
+# MECS year is 2018
+# CoA year is 2017
 
-_allocation_types:
-  _mecs_allocation: &fuel_MECS
-    # names: # override this
-    allocation_source: "EIA_MECS_Energy"
-    allocation_method: proportional
-    allocation_source_class: "Energy"
-    allocation_source_year: 2014
-    # allocation_flow:  # override this
-    #   - "Coal"
-    allocation_compartment: None
-    allocation_from_scale: national
-    allocation_selection_fields:
-        Description:
-            - "Table 2.2"  # Nonfuel (class Other)
-            - "Table 3.2"  # Fuel (class Energy)
-    clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
-    clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
-    helper_source: "BLS_QCEW"
-    helper_method: proportional-flagged
-    helper_source_class: "Employment"
-    helper_source_year: 2014
-    helper_flow: None
-    helper_from_scale: national
-    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
-
-
-  _use_allocation: &use_allocation
-    # names: # override this
-    allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
-    activity_to_sector_mapping: "BEA_2012_Detail"
-    allocation_method: proportional
-    allocation_source_class: "Money"
-    allocation_source_year: 2012
-    allocation_flow:
-      - "USD2012"
-    allocation_compartment: None
-    allocation_from_scale: national
-    clean_allocation_fba: !script_function:BEA subset_BEA_table
-    # clean_parameter: {"324110": 'ActivityProducedBy'}  # override this
-    helper_source: "BLS_QCEW"
-    helper_method: proportional
-    helper_source_class: "Employment"
-    helper_source_year: 2012
-    helper_flow: None
-    helper_from_scale: national
-    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
-
-
-target_sector_level: NAICS_6
-target_sector_source: NAICS_2012_Code
-target_geoscale: national
+!include:GHG_national_m1.yaml
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
     year: &ghgi_year 2016
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      direct:
-        names:
-          - "Iron and Steel Production & Metallurgical Coke Production" #CO2, CH4
-          - "Cement Production" #CO2
-          - "Lime Production" #CO2
-          - "Ammonia Production" #CO2
-          - "Incineration of Waste" #CO2, #N2O
-          - "Aluminum Production" #CO2
-          - "Soda Ash Production" #CO2
-          - "Ferroalloy Production" #CO2, CH4
-          - "Titanium Dioxide Production" #CO2
-          - "Zinc Production" #CO2
-          - "Phosphoric Acid Production" #CO2
-          - "Glass Production" #CO2
-          - "Carbide Production and Consumption" #CO2, CH4
-          - "Landfills" #CH4
-          - "Coal Mining" #CO2, CH4
-          - "Wastewater Treatment" #CH4, N2O
-          - "Rice Cultivation" #CH4
-          - "Abandoned Oil and Gas Wells" #CH4
-          - "Abandoned Underground Coal Mines" #CH4
-          - "Anaerobic Digestion at Biogas Facilities" #CH4 new activity
-          - "Composting" #CH4, N2O
-          - "Nitric Acid Production" #N2O
-          - "Adipic Acid Production" #N2O
-          - "Caprolactam, Glyoxal, and Glyoxylic Acid Production" #N2O
-        source_flows: ["CO2", "CH4", "N2O"] # HFCs and other flows are pulled elsewhere
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      electricity_transmission:
-        names:
-          - "Electrical Transmission and Distribution" #SF6
-        source_flows: ["SF6"]
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      electric_power: &make_allocation
-        names:
-        - "Electric Power Sector" #CO2
-        allocation_method: proportional
-        allocation_source: "BEA_Make_Detail_BeforeRedef"
-        activity_to_sector_mapping: "BEA_2012_Detail"
-        allocation_source_class: "Money"
-        allocation_source_year: 2012
-        allocation_flow:
-          - "USD2012"
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:BEA subset_BEA_table
-        clean_parameter: {"221100": 'ActivityConsumedBy'} # Electricity
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
-        helper_source_year: 2012
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
-      liming:
-        <<: *use_allocation
-        names:
-        - "Liming"  #CO2
-        clean_parameter: {"327400": 'ActivityProducedBy'} # Lime
-      urea:
-        <<: *use_allocation
-        names:
-        - "Urea Fertilization" #CO2
-        - "Urea Consumption for Non-Agricultural Purposes" #CO2
-        clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
-      carbonates:
-        <<: *use_allocation
-        names:
-        - "Other Process Uses of Carbonates" #CO2
-        clean_parameter: {"325180": 'ActivityProducedBy'} # Other Basic Inorganic Chemicals
+    activity_sets: # Update USGS year for these activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
-        names:
-        - "Lead Production" #CO2
-        allocation_method: proportional
-        allocation_source: "USGS_MYB_Lead"
-        allocation_source_class: "Geological"
-        allocation_source_year: 2016
-        allocation_compartment: None
-        allocation_from_scale: national
-      N2O_products:
-        <<: *use_allocation
-        names:
-        - "N2O from Product Uses" #N2O
-        clean_parameter: {"325120": 'ActivityProducedBy'} # Industrial gases
-
-## Fossil Fuels
-  "EPA_GHGI_T_3_68": &natgas #CH4 from Natural Gas Systems
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
+        allocation_source_year: *ghgi_year
+  "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      nat_gas:
-        names:
-          - "Distribution"
-          - "Distribution - Post-Meter"
-          - "Exploration"
-          - "Processing"
-          - "Production"
-          - "Transmission and Storage"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-  "EPA_GHGI_T_3_70": *natgas #CO2 from Natural Gas Systems mimics CH4
-  "EPA_GHGI_T_3_72": *natgas #N2O from Natural Gas Systems, not used in original method, mimics CH4
-  "EPA_GHGI_T_3_42": &petroleum #CH4 from Petroleum Systems
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+  "EPA_GHGI_T_3_70": #CO2 from Natural Gas Systems mimics CH4
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_70
     year: *ghgi_year
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      petroleum:
-        names:
-          - "Crude Oil Transportation"
-          - "Exploration"
-          - "Production"
-          - "Refining"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-  "EPA_GHGI_T_3_44": *petroleum #CO2 from Petroleum Systems mimics CH4
-  "EPA_GHGI_T_3_46": *petroleum #N2O from Petroleum Systems, not in prior method, mimics CH4
-
-## Agriculture
+  "EPA_GHGI_T_3_72":  #N2O from Natural Gas Systems, not used in original method, mimics CH4
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_72
+    year: *ghgi_year
+  "EPA_GHGI_T_3_42": #CH4 from Petroleum Systems
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_42
+    year: *ghgi_year
+  "EPA_GHGI_T_3_44": #CO2 from Petroleum Systems mimics CH4
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_44
+    year: *ghgi_year
+  "EPA_GHGI_T_3_46": #N2O from Petroleum Systems mimics CH4
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_46
+    year: *ghgi_year
   "EPA_GHGI_T_5_28": #CH4, N2O, CO and NOx from field burning of residues
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        crops:
-          names:
-            - "Chickpeas"
-            - "Cotton"
-            - "Maize"
-            - "Rice"
-            - "Soybeans"
-            - "Wheat"
-          allocation_method: direct
-          allocation_source: None
-          allocation_from_scale: national
-  "EPA_GHGI_T_5_3":  &animals #CH4 from Enteric Fermentation
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_28
     year: *ghgi_year
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      animals:
-        names:
-          - "American Bison"
-          - "Beef Cattle"
-          - "Dairy Cattle"
-          - "Goats"
-          - "Horses"
-          - "Mules and Asses"
-          - "Sheep"
-          - "Swine"
-          - "Poultry"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-  "EPA_GHGI_T_5_6": *animals #CH4 and N2O from manure, mimics enteric fermentation
-
+  "EPA_GHGI_T_5_3": #CH4 from Enteric Fermentation
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_3
+    year: *ghgi_year
+  "EPA_GHGI_T_5_6": #CH4 and N2O from manure, mimics enteric fermentation
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_6
+    year: *ghgi_year
   "EPA_GHGI_T_5_17": #Direct N2O emissions from agricultural soils
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_17
     year: *ghgi_year
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      fertilizer_use:  # allocated based on fertilizer use
-        <<: *use_allocation
-        names:
-            - "Organic Amendment Cropland"
-            - "Residue N Cropland"
-            - "Synthetic Fertilizer Cropland"
-        clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
-      land_area:  # allocated based on USDA land area harvested
-        names:
-            - "Mineralization and Asymbiotic Fixation Cropland"
-            - "Drained Organic Soils Cropland"
-        allocation_source: "USDA_CoA_Cropland"
-        allocation_method: proportional
-        allocation_source_class: "Land"
-        allocation_source_year: 2017
-        allocation_flow:
-          - "AREA HARVESTED"
-          - "AREA BEARING & NON-BEARING" # Orchards
-          - "AREA GROWN" # Berry totals
-          - "AREA IN PRODUCTION" # Vegetable totals
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba_w_sec: !script_function:USDA_CoA_Cropland disaggregate_coa_cropland_to_6_digit_naics
-      grassland: &grassland # allocated based on USDA Animal operation land (acres)
-        names:
-            - "All activities Grassland"
-        allocation_method: proportional
-        allocation_source: "USDA_CoA_Cropland_NAICS"
-        allocation_source_class: "Land"
-        allocation_source_year: 2017
-        allocation_flow:
-          - "FARM OPERATIONS"
-        allocation_compartment: None
-        allocation_from_scale: national
-
   "EPA_GHGI_T_5_18": #Indirect N2O emissions from agricultural soils
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_18
     year: *ghgi_year
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      fertilizer_use:  # allocated based on fertilizer use
-        <<: *use_allocation
-        names:
-            - "Volatilization & Atm. Deposition Cropland"
-            - "Surface Leaching & Run-Off Cropland"
-        clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
-      grassland: *grassland # allocated based on USDA Animal operation land (acres)
-
-
-## Mobile Sources
-  # "EPA_GHGI_T_3_13": #CO2 from mobile combustion
-  #   data_format: 'FBA'
-  #   class: Chemicals
-  #   geoscale_to_use: national
-  #   year: *ghgi_year
-  #   fedefl_mapping: 'GHGI'
-  #   activity_sets:
-  #     activity_set_1:  #this set is direct
-  #       names:
-  #           - "Pipeline Natural Gas"
-  #           - "General Aviation Aircraft Aviation Gasoline"
-  #           - "General Aviation Aircraft Jet Fuel"
-  #           - "Commercial Aircraft Jet Fuel"
-  #           - "Military Aircraft Jet Fuel"
-  #           - "Ships and Non-Recreational Boats Residual Fuel Oil"
-  #       allocation_method: direct
-  #       allocation_source: None
-  #       allocation_from_scale: national
-
-  "EPA_GHGI_T_3_14": &mobile #CH4 from mobile combustion
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+  "EPA_GHGI_T_3_14": #CH4 from mobile combustion
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_14
     year: *ghgi_year
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      direct:  #this set is direct
-        names:
-            - "Passenger Cars Gasoline On-Road"
-            - "Passenger Cars Diesel On-Road"
-            - "Light-Duty Trucks Gasoline On-Road"
-            - "Rail Non-Road"
-            - "Ships and Boats Non-Road"
-            - "Aircraft Non-Road"
-            - "Light-Duty Trucks Diesel On-Road"
-            - "Medium- and Heavy-Duty Trucks Diesel On-Road"
-            - "Medium- and Heavy-Duty Buses Diesel On-Road"
-            - "Medium- and Heavy-Duty Trucks and Buses Gasoline On-Road"
-            - "Motorcycles Gasoline On-Road"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      construction: #this set is allocated by purchases of construction equipment
-        <<: *use_allocation
-        names:
-          - "Construction/Mining Equipment Non-Road"
-        clean_parameter: {"333120": 'ActivityProducedBy'} # purchases of construction equipment
-      ag: #this set is allocated by purchases of farm machinery
-        <<: *use_allocation
-        names:
-          - "Agricultural Equipment Non-Road"
-        clean_parameter: {"333111": 'ActivityProducedBy'} # purchases of farm machinery
-      other_non_road: #this set is allocated by purchases of petroleum refining
-        <<: *use_allocation
-        names:
-          - "Other Non-Road"
-        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery products
-      alternatives: #this set is allocated by purchases of natural gas
-        <<: *use_allocation
-        names:
-          - "Alternative Fuel On-Road"
-        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-  "EPA_GHGI_T_3_15": *mobile #N2O from mobile combustion duplicates method for CH4
+  "EPA_GHGI_T_3_15": #N2O from mobile combustion duplicates method for CH4
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_15
+    year: *ghgi_year
+  "EPA_GHGI_T_4_46": #CO2 for selected petrochemicals
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_46
+    year: *ghgi_year
+  "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_50
+    year: *ghgi_year
+  "EPA_GHGI_T_4_96": # HFCs and other emissions from electronics manufacture
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_96
+    year: *ghgi_year
+  "EPA_GHGI_T_4_102": # HFCs and PFCs from ODS Substitutes
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_102
+    year: *ghgi_year
+  "EPA_GHGI_T_A_97": # HFCs from Transportation
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_A_97
+    year: *ghgi_year
+  "EPA_GHGI_T_4_80": # PFCs from aluminum production
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_80
+    year: *ghgi_year
+  "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
+    year: *ghgi_year
+  "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    year: *ghgi_year
+    activity_sets: # Update EIA_MECS year for some activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      petroleum:
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        allocation_source_year: &mecs_year 2018
+        helper_source_year: *mecs_year
+      natural_gas:
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
 ## Major CO2 Sources
-  "EPA_GHGI_T_A_9":  # CO2 emissions from stationary combustion and transportation
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
-    year: 2016 # Table A_9 is specific to 2016
-    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      direct:
-        names:
-            - "Total (All Fuels) Residential"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      coal:
-        <<: *use_allocation
-        names:
-            - "Commercial Coal Commercial"
-            - "Industrial Other Coal Industrial"
-        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
-      natural_gas:
-        <<: *use_allocation
-        names:
-            - "Natural Gas Commercial"
-            - "Natural Gas Industrial"
-        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-      petroleum:
-        <<: *use_allocation
-        names:
-            - "Total Petroleum Commercial"
-            - "Total Petroleum Industrial"
-        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
+  "EPA_GHGI_T_A_9":  # CO2 emissions from stationary combustion and transportation. This table number changes with year
+    !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
+    year: *ghgi_year
+    activity_sets: # Update EIA_MECS year for some activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Industrial Other Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
-        names:
-            - "Natural Gas Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Natural Gas']
-        allocation_compartment: None
-        allocation_from_scale: national
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
         helper_source_year: *ghgi_year
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
       aviation_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
-        names:
-            - "Aviation Gasoline Transportation"
-        allocation_flow: ['Aviation Gasoline']
       jet_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:jet_transport
         <<: *transport_direct
-        names:
-            - "Jet Fuel Transportation"
-        allocation_flow: ['Jet Fuel']
       lpg_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:lpg_transport
         <<: *transport_direct
-        names:
-            - "LPG (Propane) Transportation"
-        allocation_flow: ['LPG']
       rfo_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:rfo_transport
         <<: *transport_direct
-        names:
-            - "Residual Fuel Transportation"
-        allocation_flow: ['Residual Fuel Oil']
       dfo_transport: &transport_use
-        names:
-            - "Distillate Fuel Oil Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:dfo_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Distillate Fuel Oil']
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
-        clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
-        helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        helper_activity_to_sector_mapping: "BEA_2012_Detail"
-        helper_method: proportional
-        helper_source_class: "Money"
-        helper_source_year: 2012
-        helper_flow: ["USD2012"]
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
-        clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
       gasoline_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:gasoline_transport
         <<: *transport_use
-        names:
-            - "Motor Gasoline Transportation"
-        allocation_flow: ['Motor Gasoline']
 
-
-## Stationary Combustion
-  "EPA_GHGI_T_3_8":  &stationary_combustion # CH4 emissions from stationary combustion
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
+  "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
-    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
-    fedefl_mapping: 'GHGI'
     activity_sets:
-      residential:
-        names:
-            - "Fuel Oil Residential"
-            - "Coal Residential"
-            - "Natural Gas Residential"
-            - "Wood Residential"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      electric_power:
-        <<: *make_allocation
-        names:
-            - "Coal Electric Power"
-            - "Natural Gas Electric Power"
-            - "Fuel Oil Electric Power"
-            - "Wood Electric Power"
-        clean_parameter: {"221100": 'ActivityConsumedBy'} # Electricity
-      fuel_oil:
-        <<: *use_allocation
-        names:
-            - "Fuel Oil Commercial"
-            - "Fuel Oil Industrial"
-        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
-      natural_gas: # Commercial Natural gas
-        <<: *use_allocation
-        names:
-            - "Natural Gas Commercial"
-            - "Natural Gas Industrial"
-        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-      coal:
-        <<: *use_allocation
-        names:
-            - "Coal Industrial"
-        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
-      coal_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
+      coal_manufacturing:
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
-    ## TODO MISSING 'Wood Commercial' and 'Wood Industrial'
+  "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
+    year: *ghgi_year
+    activity_sets:
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
+      coal_manufacturing:
+       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
+      ng_manufacturing: # Industrial
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
-  "EPA_GHGI_T_3_9":
-      <<: *stationary_combustion # N2O emissions from stationary combustion
-
-## Other sources
-  "EPA_GHGI_T_4_46": #CO2 for selected petrochemicals
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        direct:
-          names:
-            - "Acrylonitrile"
-            - "Carbon Black"
-            - "Ethylene"
-            - "Ethylene Dichloride"
-            - "Ethylene Oxide"
-            - "Methanol"
-          allocation_method: direct
-          allocation_source: None
-          allocation_from_scale: national
-  "EPA_GHGI_T_3_22b": # Fossil fuel for non-energy uses
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        coal:
-          names:
-            - "Industry Industrial Coking Coal"
-            - "Industry Industrial Other Coal"
-          allocation_method: direct
-          allocation_from_scale: national
-        petroleum:
-          <<: *fuel_MECS
-          names:
-            - "Industry Asphalt & Road Oil"
-            - "Industry Distillate Fuel Oil"
-            - "Industry LPG"
-            - "Industry Lubricants"
-            - "Industry Miscellaneous Products"
-            - "Industry Naphtha (<401 F)"
-            - "Industry Other Oil (>401 F)"
-            - "Industry Pentanes Plus"
-            - "Industry Petroleum Coke"
-            - "Industry Special Naphtha"
-            - "Industry Still Gas"
-            - "Industry Waxes"
-          allocation_source: "EIA_MECS_Energy"
-          allocation_source_class: "Other" # nonfuel consumption
-          allocation_flow:
-            - "Other" # consistent with original, but other flows may be better
-        natural_gas: # consumed nat gas to chemical plants
-          <<: *fuel_MECS
-          names:
-            - "Industry Natural Gas to Chemical Plants"
-          allocation_source: "EIA_MECS_Energy"
-          allocation_source_class: "Other" # nonfuel consumption
-          allocation_flow:
-            - "Natural Gas"
-        transport_lubricants:
-          <<: *use_allocation
-          names:
-            - "Transportation Lubricants"
-          clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
-
-## Other Emissions
-  "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI remove_HFC_kt
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        direct:
-          names:
-            - "HCFC-22 Production"
-          allocation_method: direct
-          allocation_from_scale: national
-  "EPA_GHGI_T_4_96": # HFCs and other emissions from electronics manufacture
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        direct:
-          names:
-            - "Electronics Production"
-          allocation_method: direct
-          allocation_from_scale: national
-  "EPA_GHGI_T_4_102": # HFCs and PFCs from ODS Substitutes
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI clean_HFC_fba # removes HFCs from transportation
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        households:
-          names:
-            - "Refrigeration/Air Conditioning - Households"
-          allocation_method: direct
-          allocation_from_scale: national
-        refrigerants:
-          <<: *use_allocation
-          names:
-            - "Refrigeration/Air Conditioning"
-          clean_parameter: {"333415": 'ActivityProducedBy'} # Air conditioning equipment
-        foams_polystyrene:
-          <<: *use_allocation
-          names:
-            - "Foams - Polystyrene"
-          clean_parameter: {"326140": 'ActivityProducedBy'} # Polystyrene foam
-        foams_urethane:
-          <<: *use_allocation
-          names:
-            - "Foams - Urethane"
-          clean_parameter: {"326150": 'ActivityProducedBy'} # Urethane and other foam
-  "EPA_GHGI_T_A_97": # HFCs from Transportation
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI split_HFCs_by_type
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        direct:
-          names:
-            - "Mobile AC - Passenger Cars"
-            - "Mobile AC - Heavy-Duty Vehicles"
-            - "Mobile AC - Light-Duty Trucks"
-            - "Comfort Cooling for Trains and Buses - School and Tour Buses"
-            - "Comfort Cooling for Trains and Buses - Rail"
-            - "Refrigerated Transport - Medium- and Heavy-Duty Trucks"
-            - "Refrigerated Transport - Rail"
-            - "Refrigerated Transport - Ships and Boats"
-          allocation_method: direct
-          allocation_from_scale: national
-  "EPA_GHGI_T_4_80": # PFCs from aluminum production
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        aluminum:
-          names:
-            - "Aluminum Production"
-          allocation_method: direct
-          allocation_from_scale: national
-  "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        magnesium:
-            <<: *make_allocation # Make table allocation
-            names:
-            - "Magnesium Production and Processing"
-            clean_parameter: {"T008": 'ActivityConsumedBy'} # Gross Output

--- a/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
@@ -3,9 +3,7 @@
 # MECS year is 2018
 # CoA year is 2017
 
-target_sector_level: NAICS_6
-target_sector_source: NAICS_2012_Code
-target_geoscale: national
+!include:GHG_national_m1.yaml
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1

--- a/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
@@ -1,272 +1,158 @@
-# m1 for the GHG national replicates the method used in the National GHG
-# Industry Attribution Model (https://doi.org/10.23719/1517571), except that
-# sector attribution is to 6-digit NAICS, rather than the BEA 2012 IO schema
-
-# Differences from 2017 method are 1) source year, 2) replace A-9 with A-8
-# (2017)
+# This is a 2017 target year specific implementation of GHG_national_m1
+# GHGI year is always 2017
+# MECS year is 2018
+# CoA year is 2017
 
 target_sector_level: NAICS_6
 target_sector_source: NAICS_2012_Code
 target_geoscale: national
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
     year: &ghgi_year 2017
     activity_sets: # Update USGS year for these activity_sets
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
         allocation_source_year: *ghgi_year
   "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_68
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year
   "EPA_GHGI_T_3_70": #CO2 from Natural Gas Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_70
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_70
     year: *ghgi_year
   "EPA_GHGI_T_3_72":  #N2O from Natural Gas Systems, not used in original method, mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_72
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_72
     year: *ghgi_year
   "EPA_GHGI_T_3_42": #CH4 from Petroleum Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_42
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_42
     year: *ghgi_year
   "EPA_GHGI_T_3_44": #CO2 from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_44
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_44
     year: *ghgi_year
   "EPA_GHGI_T_3_46": #N2O from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_46
     year: *ghgi_year
   "EPA_GHGI_T_5_28": #CH4, N2O, CO and NOx from field burning of residues
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_28
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_28
     year: *ghgi_year
   "EPA_GHGI_T_5_3": #CH4 from Enteric Fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_3
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_3
     year: *ghgi_year
   "EPA_GHGI_T_5_6": #CH4 and N2O from manure, mimics enteric fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_6
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_6
     year: *ghgi_year
   "EPA_GHGI_T_5_17": #Direct N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_17
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_17
     year: *ghgi_year
   "EPA_GHGI_T_5_18": #Indirect N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_18
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_18
     year: *ghgi_year
   # "EPA_GHGI_T_3_13": #C02 from mobile combustion
-  #   !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_13
+  #   !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_13
   #   year: *ghgi_year
   "EPA_GHGI_T_3_14": #CH4 from mobile combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_14
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_14
     year: *ghgi_year
   "EPA_GHGI_T_3_15": #N2O from mobile combustion duplicates method for CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_15
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_15
     year: *ghgi_year
   "EPA_GHGI_T_4_46": #CO2 for selected petrochemicals
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_46
     year: *ghgi_year
   "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_50
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_50
     year: *ghgi_year
   "EPA_GHGI_T_4_96": # HFCs and other emissions from electronics manufacture
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_96
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_96
     year: *ghgi_year
   "EPA_GHGI_T_4_102": # HFCs and PFCs from ODS Substitutes
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_102
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_102
     year: *ghgi_year
   "EPA_GHGI_T_A_97": # HFCs from Transportation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_A_97
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_A_97
     year: *ghgi_year
   "EPA_GHGI_T_4_80": # PFCs from aluminum production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_80
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_80
     year: *ghgi_year
   "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_86
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
   "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
       petroleum:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
-        allocation_source_year: 2018
-        helper_source_year: 2018
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        allocation_source_year: &mecs_year 2018
+        helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
-        allocation_source_year: 2018
-        helper_source_year: 2018
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
 ## Major CO2 Sources
   "EPA_GHGI_T_A_8":  # CO2 emissions from stationary combustion and transportation
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
-    year: 2017 # Table A_8 is specific to 2017
-    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      direct:
-        names:
-            - "Total (All Fuels) Residential"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      coal: &use_allocation
-        names:
-            - "Commercial Coal Commercial"
-            - "Industrial Other Coal Industrial"
-        allocation_method: proportional
-        allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        activity_to_sector_mapping: "BEA_2012_Detail"
-        allocation_source_class: "Money"
-        allocation_source_year: 2012
-        allocation_flow:
-          - "USD2012"
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:BEA subset_BEA_table
-        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
-        helper_source_year: 2012
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
-      natural_gas:
-        <<: *use_allocation
-        names:
-            - "Natural Gas Commercial"
-            - "Natural Gas Industrial"
-        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-      petroleum:
-        <<: *use_allocation
-        names:
-            - "Total Petroleum Commercial"
-            - "Total Petroleum Industrial"
-        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
-      coal_manufacturing: &fuel_MECS # Industrial Coal for Manufacturing
-        names:
-            - "Industrial Other Coal Industrial - Manufacturing"
-        allocation_method: proportional
-        allocation_source: "EIA_MECS_Energy"
-        allocation_source_class: "Energy" # fuel consumption
-        allocation_source_year: 2018
-        allocation_flow:
-            - "Coal"
-        allocation_compartment: None
-        allocation_from_scale: national
-        allocation_selection_fields:
-            Description:
-                - "Table 2.2"  # Nonfuel (class Other)
-                - "Table 3.2"  # Fuel (class Energy)
-        clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
-        clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
-        helper_source: "BLS_QCEW"
-        helper_method: proportional-flagged
-        helper_source_class: "Employment"
-        helper_source_year: 2018
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+    !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
+    year: *ghgi_year # Table A_8 is specific to 2017
+    activity_sets: # Update EIA_MECS year for some activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
+      coal_manufacturing:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
-        names:
-            - "Natural Gas Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Natural Gas']
-        allocation_compartment: None
-        allocation_from_scale: national
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
         helper_source_year: *ghgi_year
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
       aviation_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
-        names:
-            - "Aviation Gasoline Transportation"
-        allocation_flow: ['Aviation Gasoline']
       jet_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:jet_transport
         <<: *transport_direct
-        names:
-            - "Jet Fuel Transportation"
-        allocation_flow: ['Jet Fuel']
       lpg_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:lpg_transport
         <<: *transport_direct
-        names:
-            - "LPG (Propane) Transportation"
-        allocation_flow: ['LPG']
       rfo_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:rfo_transport
         <<: *transport_direct
-        names:
-            - "Residual Fuel Transportation"
       dfo_transport: &transport_use
-        names:
-            - "Distillate Fuel Oil Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:dfo_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Distillate Fuel Oil']
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
-        clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
-        helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        helper_activity_to_sector_mapping: "BEA_2012_Detail"
-        helper_method: proportional
-        helper_source_class: "Money"
-        helper_source_year: 2012
-        helper_flow: ["USD2012"]
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
-        clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
       gasoline_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:gasoline_transport
         <<: *transport_use
-        names:
-            - "Motor Gasoline Transportation"
-        allocation_flow: ['Motor Gasoline']
 
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
@@ -75,16 +75,16 @@ source_names:
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
   "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
         allocation_source_year: &mecs_year 2018
         helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
         helper_source_year: *mecs_year
 

--- a/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
@@ -5,10 +5,18 @@
 # CoA year is 2017
 
 !include:GHG_national_m1.yaml
+ghgi_year: &ghgi_year 2017
+mecs_year: &mecs_year 2018
+
+_industrial_allocation_dict: &industrial_dict
+    energy_fba: 'EIA_MECS_Energy'
+    year: *mecs_year
+    ghg_fba: 'EPA_GHGI_T_A_7' # 2018 Table
+
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
-    year: &ghgi_year 2017
+    year: *ghgi_year
     activity_sets: # Update USGS year for these activity_sets
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
@@ -81,32 +89,28 @@ source_names:
       !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
-        allocation_source_year: &mecs_year 2018
-        helper_source_year: *mecs_year
+        allocation_source_year: *mecs_year
       natural_gas:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
-## Major CO2 Sources
+### Major CO2 Sources
   "EPA_GHGI_T_A_8":  # CO2 emissions from stationary combustion and transportation
     !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
     year: *ghgi_year # Table A_8 is specific to 2017
+    clean_parameter: *industrial_dict
     activity_sets: # Update EIA_MECS year for some activity_sets
       !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        helper_source_year: *ghgi_year
       aviation_transport:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
@@ -129,27 +133,25 @@ source_names:
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
@@ -1,5 +1,6 @@
 # This is a 2017 target year specific implementation of GHG_national_m1
-# GHGI year is always 2017
+# All parameters add year specific data when needed to implement for 2017
+# GHGI FBA table names match the 2022 GHGI Report
 # MECS year is 2018
 # CoA year is 2017
 
@@ -46,9 +47,6 @@ source_names:
   "EPA_GHGI_T_5_18": #Indirect N2O emissions from agricultural soils
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_18
     year: *ghgi_year
-  # "EPA_GHGI_T_3_13": #C02 from mobile combustion
-  #   !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_13
-  #   year: *ghgi_year
   "EPA_GHGI_T_3_14": #CH4 from mobile combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_14
     year: *ghgi_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2017_m1.yaml
@@ -138,6 +138,7 @@ source_names:
         allocation_source_year: *mecs_year
         helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
         helper_source_year: *mecs_year
 

--- a/flowsa/methods/flowbysectormethods/GHG_national_2018_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2018_m1.yaml
@@ -5,10 +5,18 @@
 # CoA year is 2017
 
 !include:GHG_national_m1.yaml
+ghgi_year: &ghgi_year 2018
+mecs_year: &mecs_year 2018
+
+_industrial_allocation_dict: &industrial_dict
+    energy_fba: 'EIA_MECS_Energy'
+    year: *mecs_year
+    ghg_fba: 'EPA_GHGI_T_A_7' # 2018 Table
+
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
-    year: &ghgi_year 2018
+    year: *ghgi_year
     activity_sets: # Update USGS year for these activity_sets
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
@@ -81,32 +89,28 @@ source_names:
       !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
-        allocation_source_year: &mecs_year 2018
-        helper_source_year: *mecs_year
+        allocation_source_year: *mecs_year
       natural_gas:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
-## Major CO2 Sources
+### Major CO2 Sources
   "EPA_GHGI_T_A_7":  # CO2 emissions from stationary combustion and transportation. This table number varies by GHG year
     !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
-    year: *ghgi_year # Table A_8 is specific to 2017
+    year: *ghgi_year # Table A_7 is specific to 2018
+    clean_parameter: *industrial_dict
     activity_sets: # Update EIA_MECS year for some activity_sets
       !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        helper_source_year: *ghgi_year
       aviation_transport:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
@@ -129,27 +133,25 @@ source_names:
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2018_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2018_m1.yaml
@@ -75,16 +75,16 @@ source_names:
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
   "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
         allocation_source_year: &mecs_year 2018
         helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
         helper_source_year: *mecs_year
 

--- a/flowsa/methods/flowbysectormethods/GHG_national_2018_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2018_m1.yaml
@@ -1,272 +1,155 @@
-# m1 for the GHG national replicates the method used in the National GHG
-# Industry Attribution Model (https://doi.org/10.23719/1517571), except that
-# sector attribution is to 6-digit NAICS, rather than the BEA 2012 IO schema
+# This is a 2018 target year specific implementation of GHG_national_m1
+# All parameters add year specific data when needed to implement for 2018
+# GHGI FBA table names match the 2022 GHGI Report
+# MECS year is 2018
+# CoA year is 2017
 
-# Differences from 2016 method are 1) source year, 2) replace A-9 with A-7
-# (2018)
-
-target_sector_level: NAICS_6
-target_sector_source: NAICS_2012_Code
-target_geoscale: national
+!include:GHG_national_m1.yaml
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
     year: &ghgi_year 2018
     activity_sets: # Update USGS year for these activity_sets
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
         allocation_source_year: *ghgi_year
   "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_68
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year
   "EPA_GHGI_T_3_70": #CO2 from Natural Gas Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_70
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_70
     year: *ghgi_year
   "EPA_GHGI_T_3_72":  #N2O from Natural Gas Systems, not used in original method, mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_72
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_72
     year: *ghgi_year
   "EPA_GHGI_T_3_42": #CH4 from Petroleum Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_42
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_42
     year: *ghgi_year
   "EPA_GHGI_T_3_44": #CO2 from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_44
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_44
     year: *ghgi_year
   "EPA_GHGI_T_3_46": #N2O from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_46
     year: *ghgi_year
   "EPA_GHGI_T_5_28": #CH4, N2O, CO and NOx from field burning of residues
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_28
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_28
     year: *ghgi_year
   "EPA_GHGI_T_5_3": #CH4 from Enteric Fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_3
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_3
     year: *ghgi_year
   "EPA_GHGI_T_5_6": #CH4 and N2O from manure, mimics enteric fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_6
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_6
     year: *ghgi_year
   "EPA_GHGI_T_5_17": #Direct N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_17
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_17
     year: *ghgi_year
   "EPA_GHGI_T_5_18": #Indirect N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_18
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_18
     year: *ghgi_year
-  # "EPA_GHGI_T_3_13": #C02 from mobile combustion
-  #   !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_13
-  #   year: *ghgi_year
   "EPA_GHGI_T_3_14": #CH4 from mobile combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_14
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_14
     year: *ghgi_year
   "EPA_GHGI_T_3_15": #N2O from mobile combustion duplicates method for CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_15
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_15
     year: *ghgi_year
   "EPA_GHGI_T_4_46": #CO2 for selected petrochemicals
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_46
     year: *ghgi_year
   "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_50
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_50
     year: *ghgi_year
   "EPA_GHGI_T_4_96": # HFCs and other emissions from electronics manufacture
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_96
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_96
     year: *ghgi_year
   "EPA_GHGI_T_4_102": # HFCs and PFCs from ODS Substitutes
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_102
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_102
     year: *ghgi_year
   "EPA_GHGI_T_A_97": # HFCs from Transportation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_A_97
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_A_97
     year: *ghgi_year
   "EPA_GHGI_T_4_80": # PFCs from aluminum production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_80
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_80
     year: *ghgi_year
   "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_86
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
   "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
       petroleum:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
-        allocation_source_year: 2018
-        helper_source_year: 2018
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        allocation_source_year: &mecs_year 2018
+        helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
-        allocation_source_year: 2018
-        helper_source_year: 2018
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
 ## Major CO2 Sources
-  "EPA_GHGI_T_A_7":  # CO2 emissions from stationary combustion and transportation
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
-    year: 2018 # Table A_7 is specific to 2018
-    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      direct: #direct allocation
-        names:
-            - "Total (All Fuels) Residential"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      coal: &use_allocation # Coal
-        names:
-            - "Commercial Coal Commercial"
-            - "Industrial Other Coal Industrial"
-        allocation_method: proportional
-        allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        activity_to_sector_mapping: "BEA_2012_Detail"
-        allocation_source_class: "Money"
-        allocation_source_year: 2012
-        allocation_flow:
-          - "USD2012"
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:BEA subset_BEA_table
-        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
-        helper_source_year: 2012
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
-      natural_gas: # Natural Gas
-        <<: *use_allocation
-        names:
-            - "Natural Gas Commercial"
-            - "Natural Gas Industrial"
-        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-      petroleum: # Petroleum
-        <<: *use_allocation
-        names:
-            - "Total Petroleum Commercial"
-            - "Total Petroleum Industrial"
-        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
-      coal_manufacturing: &fuel_MECS # Industrial Coal for Manufacturing
-        names:
-            - "Industrial Other Coal Industrial - Manufacturing"
-        allocation_method: proportional
-        allocation_source: "EIA_MECS_Energy"
-        allocation_source_class: "Energy" # fuel consumption
-        allocation_source_year: 2018
-        allocation_flow:
-            - "Coal"
-        allocation_compartment: None
-        allocation_from_scale: national
-        allocation_selection_fields:
-            Description:
-                - "Table 2.2"  # Nonfuel (class Other)
-                - "Table 3.2"  # Fuel (class Energy)
-        clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
-        clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
-        helper_source: "BLS_QCEW"
-        helper_method: proportional-flagged
-        helper_source_class: "Employment"
-        helper_source_year: 2018
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+  "EPA_GHGI_T_A_7":  # CO2 emissions from stationary combustion and transportation. This table number varies by GHG year
+    !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
+    year: *ghgi_year # Table A_8 is specific to 2017
+    activity_sets: # Update EIA_MECS year for some activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
+      coal_manufacturing:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
-        names:
-            - "Natural Gas Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Natural Gas']
-        allocation_compartment: None
-        allocation_from_scale: national
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
         helper_source_year: *ghgi_year
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
       aviation_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
-        names:
-            - "Aviation Gasoline Transportation"
-        allocation_flow: ['Aviation Gasoline']
       jet_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:jet_transport
         <<: *transport_direct
-        names:
-            - "Jet Fuel Transportation"
-        allocation_flow: ['Jet Fuel']
       lpg_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:lpg_transport
         <<: *transport_direct
-        names:
-            - "LPG (Propane) Transportation"
-        allocation_flow: ['LPG']
       rfo_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:rfo_transport
         <<: *transport_direct
-        names:
-            - "Residual Fuel Transportation"
       dfo_transport: &transport_use
-        names:
-            - "Distillate Fuel Oil Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:dfo_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Distillate Fuel Oil']
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
-        clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
-        helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        helper_activity_to_sector_mapping: "BEA_2012_Detail"
-        helper_method: proportional
-        helper_source_class: "Money"
-        helper_source_year: 2012
-        helper_flow: ["USD2012"]
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
-        clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
       gasoline_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:gasoline_transport
         <<: *transport_use
-        names:
-            - "Motor Gasoline Transportation"
-        allocation_flow: ['Motor Gasoline']
 
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        ng_manufacturing:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2019_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2019_m1.yaml
@@ -5,10 +5,18 @@
 # CoA year is 2017
 
 !include:GHG_national_m1.yaml
+ghgi_year: &ghgi_year 2019
+mecs_year: &mecs_year 2018
+
+_industrial_allocation_dict: &industrial_dict
+    energy_fba: 'EIA_MECS_Energy'
+    year: *mecs_year
+    ghg_fba: 'EPA_GHGI_T_A_7' # 2018 Table
+
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
-    year: &ghgi_year 2019
+    year: *ghgi_year
     activity_sets: # Update USGS year for these activity_sets
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
@@ -81,32 +89,28 @@ source_names:
       !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
-        allocation_source_year: &mecs_year 2018
-        helper_source_year: *mecs_year
+        allocation_source_year: *mecs_year
       natural_gas:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
-## Major CO2 Sources
+### Major CO2 Sources
   "EPA_GHGI_T_A_6":  # CO2 emissions from stationary combustion and transportation. This table number varies by GHG year.
     !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets: # Update EIA_MECS year for some activity_sets
       !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        helper_source_year: *ghgi_year
       aviation_transport:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
@@ -129,27 +133,25 @@ source_names:
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2019_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2019_m1.yaml
@@ -75,16 +75,16 @@ source_names:
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
   "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
         allocation_source_year: &mecs_year 2018
         helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
         helper_source_year: *mecs_year
 

--- a/flowsa/methods/flowbysectormethods/GHG_national_2019_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2019_m1.yaml
@@ -1,274 +1,155 @@
-# m1 for the GHG national replicates the method used in the National GHG
-# Industry Attribution Model (https://doi.org/10.23719/1517571), except that
-# sector attribution is to 6-digit NAICS, rather than the BEA 2012 IO schema
+# This is a 2019 target year specific implementation of GHG_national_m1
+# All parameters add year specific data when needed to implement for 2019
+# GHGI FBA table names match the 2022 GHGI Report
+# MECS year is 2018
+# CoA year is 2017
 
-# Differences from 2016 method are 1) source year, 2) replace A-9 with A-6
-# (2019)
-
-target_sector_level: NAICS_6
-target_sector_source: NAICS_2012_Code
-target_geoscale: national
+!include:GHG_national_m1.yaml
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
     year: &ghgi_year 2019
     activity_sets: # Update USGS year for these activity_sets
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
         allocation_source_year: *ghgi_year
   "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_68
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year
   "EPA_GHGI_T_3_70": #CO2 from Natural Gas Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_70
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_70
     year: *ghgi_year
   "EPA_GHGI_T_3_72":  #N2O from Natural Gas Systems, not used in original method, mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_72
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_72
     year: *ghgi_year
   "EPA_GHGI_T_3_42": #CH4 from Petroleum Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_42
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_42
     year: *ghgi_year
   "EPA_GHGI_T_3_44": #CO2 from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_44
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_44
     year: *ghgi_year
   "EPA_GHGI_T_3_46": #N2O from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_46
     year: *ghgi_year
   "EPA_GHGI_T_5_28": #CH4, N2O, CO and NOx from field burning of residues
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_28
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_28
     year: *ghgi_year
   "EPA_GHGI_T_5_3": #CH4 from Enteric Fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_3
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_3
     year: *ghgi_year
   "EPA_GHGI_T_5_6": #CH4 and N2O from manure, mimics enteric fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_6
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_6
     year: *ghgi_year
   "EPA_GHGI_T_5_17": #Direct N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_17
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_17
     year: *ghgi_year
   "EPA_GHGI_T_5_18": #Indirect N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_18
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_18
     year: *ghgi_year
-  # "EPA_GHGI_T_3_13": #C02 from mobile combustion
-  #   !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_13
-  #   year: *ghgi_year
   "EPA_GHGI_T_3_14": #CH4 from mobile combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_14
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_14
     year: *ghgi_year
   "EPA_GHGI_T_3_15": #N2O from mobile combustion duplicates method for CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_15
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_15
     year: *ghgi_year
   "EPA_GHGI_T_4_46": #CO2 for selected petrochemicals
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_46
     year: *ghgi_year
   "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_50
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_50
     year: *ghgi_year
   "EPA_GHGI_T_4_96": # HFCs and other emissions from electronics manufacture
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_96
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_96
     year: *ghgi_year
   "EPA_GHGI_T_4_102": # HFCs and PFCs from ODS Substitutes
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_102
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_102
     year: *ghgi_year
   "EPA_GHGI_T_A_97": # HFCs from Transportation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_A_97
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_A_97
     year: *ghgi_year
   "EPA_GHGI_T_4_80": # PFCs from aluminum production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_80
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_80
     year: *ghgi_year
   "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_86
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
   "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
       petroleum:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
-        allocation_source_year: 2018
-        helper_source_year: 2018
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        allocation_source_year: &mecs_year 2018
+        helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
-        allocation_source_year: 2018
-        helper_source_year: 2018
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
 ## Major CO2 Sources
-  "EPA_GHGI_T_A_6":  # CO2 emissions from stationary combustion and transportation
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
-    year: 2019 # Table A_6 is specific to 2019
-    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      direct: #direct allocation
-        names:
-            - "Total (All Fuels) Residential"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      coal: &use_allocation # Coal
-        names:
-            - "Commercial Coal Commercial"
-            - "Industrial Other Coal Industrial"
-        allocation_method: proportional
-        allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        activity_to_sector_mapping: "BEA_2012_Detail"
-        allocation_source_class: "Money"
-        allocation_source_year: 2012
-        allocation_flow:
-          - "USD2012"
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:BEA subset_BEA_table
-        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
-        helper_source_year: 2012
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
-      natural_gas: # Natural Gas
-        <<: *use_allocation
-        names:
-            - "Natural Gas Commercial"
-            - "Natural Gas Industrial"
-        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-      petroleum: # Petroleum
-        <<: *use_allocation
-        names:
-            - "Total Petroleum Commercial"
-            - "Total Petroleum Industrial"
-        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
-      coal_manufacturing: &fuel_MECS # Industrial Coal for Manufacturing
-        names:
-            - "Industrial Other Coal Industrial - Manufacturing"
-        allocation_method: proportional
-        allocation_source: "EIA_MECS_Energy"
-        allocation_source_class: "Energy" # fuel consumption
-        allocation_source_year: 2018
-        allocation_flow:
-            - "Coal"
-        allocation_compartment: None
-        allocation_from_scale: national
-        allocation_selection_fields:
-            Description:
-                - "Table 2.2"  # Nonfuel (class Other)
-                - "Table 3.2"  # Fuel (class Energy)
-        clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
-        clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
-        helper_source: "BLS_QCEW"
-        helper_method: proportional-flagged
-        helper_source_class: "Employment"
-        helper_source_year: 2018
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+  "EPA_GHGI_T_A_6":  # CO2 emissions from stationary combustion and transportation. This table number varies by GHG year.
+    !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
+    year: *ghgi_year
+    activity_sets: # Update EIA_MECS year for some activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
+      coal_manufacturing:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
-        names:
-            - "Natural Gas Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Natural Gas']
-        allocation_compartment: None
-        allocation_from_scale: national
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
         helper_source_year: *ghgi_year
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
       aviation_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
-        names:
-            - "Aviation Gasoline Transportation"
-        allocation_flow: ['Aviation Gasoline']
       jet_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:jet_transport
         <<: *transport_direct
-        names:
-            - "Jet Fuel Transportation"
-        allocation_flow: ['Jet Fuel']
       lpg_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:lpg_transport
         <<: *transport_direct
-        names:
-            - "LPG (Propane) Transportation"
-        allocation_flow: ['LPG']
       rfo_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:rfo_transport
         <<: *transport_direct
-        names:
-            - "Residual Fuel Transportation"
       dfo_transport: &transport_use
-        names:
-            - "Distillate Fuel Oil Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:dfo_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Distillate Fuel Oil']
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
-        clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
-        helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        helper_activity_to_sector_mapping: "BEA_2012_Detail"
-        helper_method: proportional
-        helper_source_class: "Money"
-        helper_source_year: 2012
-        helper_flow: ["USD2012"]
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
-        clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
       gasoline_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:gasoline_transport
         <<: *transport_use
-        names:
-            - "Motor Gasoline Transportation"
-        allocation_flow: ['Motor Gasoline']
 
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
@@ -1,307 +1,155 @@
-# m1 for the GHG national replicates the method used in the National GHG
-# Industry Attribution Model (https://doi.org/10.23719/1517571), except that
-# sector attribution is to 6-digit NAICS, rather than the BEA 2012 IO schema
+# This is a 2020 target year specific implementation of GHG_national_m1
+# All parameters add year specific data when needed to implement for 2020
+# GHGI FBA table names match the 2022 GHGI Report
+# MECS year is 2018
+# CoA year is 2017
 
-# Differences from 2016 method are 1) source year, 2) replace A-9 with A-5
-# (2020), 3) replace 3-22b with 3-22 (2020 data only)
-
-target_sector_level: NAICS_6
-target_sector_source: NAICS_2012_Code
-target_geoscale: national
+!include:GHG_national_m1.yaml
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
     year: &ghgi_year 2020
     activity_sets: # Update USGS year for these activity_sets
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
-        !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
-        allocation_source_year: 2019 # 2020 not yet available
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
+        allocation_source_year: *ghgi_year
   "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_68
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year
   "EPA_GHGI_T_3_70": #CO2 from Natural Gas Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_70
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_70
     year: *ghgi_year
   "EPA_GHGI_T_3_72":  #N2O from Natural Gas Systems, not used in original method, mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_72
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_72
     year: *ghgi_year
   "EPA_GHGI_T_3_42": #CH4 from Petroleum Systems
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_42
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_42
     year: *ghgi_year
   "EPA_GHGI_T_3_44": #CO2 from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_44
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_44
     year: *ghgi_year
   "EPA_GHGI_T_3_46": #N2O from Petroleum Systems mimics CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_46
     year: *ghgi_year
   "EPA_GHGI_T_5_28": #CH4, N2O, CO and NOx from field burning of residues
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_28
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_28
     year: *ghgi_year
   "EPA_GHGI_T_5_3": #CH4 from Enteric Fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_3
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_3
     year: *ghgi_year
   "EPA_GHGI_T_5_6": #CH4 and N2O from manure, mimics enteric fermentation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_6
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_6
     year: *ghgi_year
   "EPA_GHGI_T_5_17": #Direct N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_17
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_17
     year: *ghgi_year
   "EPA_GHGI_T_5_18": #Indirect N2O emissions from agricultural soils
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_5_18
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_5_18
     year: *ghgi_year
-  # "EPA_GHGI_T_3_13": #C02 from mobile combustion
-  #   !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_13
-  #   year: *ghgi_year
   "EPA_GHGI_T_3_14": #CH4 from mobile combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_14
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_14
     year: *ghgi_year
   "EPA_GHGI_T_3_15": #N2O from mobile combustion duplicates method for CH4
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_15
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_15
     year: *ghgi_year
   "EPA_GHGI_T_4_46": #CO2 for selected petrochemicals
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_46
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_46
     year: *ghgi_year
   "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_50
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_50
     year: *ghgi_year
   "EPA_GHGI_T_4_96": # HFCs and other emissions from electronics manufacture
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_96
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_96
     year: *ghgi_year
   "EPA_GHGI_T_4_102": # HFCs and PFCs from ODS Substitutes
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_102
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_102
     year: *ghgi_year
   "EPA_GHGI_T_A_97": # HFCs from Transportation
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_A_97
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_A_97
     year: *ghgi_year
   "EPA_GHGI_T_4_80": # PFCs from aluminum production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_80
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_80
     year: *ghgi_year
   "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_4_86
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
+  "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
+    year: *ghgi_year
+    activity_sets: # Update EIA_MECS year for some activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      petroleum:
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        allocation_source_year: &mecs_year 2018
+        helper_source_year: *mecs_year
+      natural_gas:
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
 ## Major CO2 Sources
-  "EPA_GHGI_T_A_5":  # CO2 emissions from stationary combustion and transportation
-    data_format: 'FBA'
-    class: Chemicals
-    geoscale_to_use: national
-    year: 2020 # Table A_5 is specific to 2020
-    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
-    fedefl_mapping: 'GHGI'
-    activity_sets:
-      direct: #direct allocation
-        names:
-            - "Total (All Fuels) Residential"
-        allocation_method: direct
-        allocation_source: None
-        allocation_from_scale: national
-      coal: &use_allocation # Coal
-        names:
-            - "Commercial Coal Commercial"
-            - "Industrial Other Coal Industrial"
-        allocation_method: proportional
-        allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        activity_to_sector_mapping: "BEA_2012_Detail"
-        allocation_source_class: "Money"
-        allocation_source_year: 2012
-        allocation_flow:
-          - "USD2012"
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:BEA subset_BEA_table
-        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
-        helper_source_year: 2012
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
-      natural_gas: # Natural Gas
-        <<: *use_allocation
-        names:
-            - "Natural Gas Commercial"
-            - "Natural Gas Industrial"
-        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-      petroleum: # Petroleum
-        <<: *use_allocation
-        names:
-            - "Total Petroleum Commercial"
-            - "Total Petroleum Industrial"
-        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
-      coal_manufacturing: &fuel_MECS # Industrial Coal for Manufacturing
-        names:
-            - "Industrial Other Coal Industrial - Manufacturing"
-        allocation_method: proportional
-        allocation_source: "EIA_MECS_Energy"
-        allocation_source_class: "Energy" # fuel consumption
-        allocation_source_year: 2018
-        allocation_flow:
-            - "Coal"
-        allocation_compartment: None
-        allocation_from_scale: national
-        allocation_selection_fields:
-            Description:
-                - "Table 2.2"  # Nonfuel (class Other)
-                - "Table 3.2"  # Fuel (class Energy)
-        clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
-        clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
-        helper_source: "BLS_QCEW"
-        helper_method: proportional-flagged
-        helper_source_class: "Employment"
-        helper_source_year: 2018
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+  "EPA_GHGI_T_A_5":  # CO2 emissions from stationary combustion and transportation. This table number varies by GHG year.
+    !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
+    year: *ghgi_year
+    activity_sets: # Update EIA_MECS year for some activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
+      coal_manufacturing:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
-        names:
-            - "Natural Gas Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Natural Gas']
-        allocation_compartment: None
-        allocation_from_scale: national
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
         helper_source_year: *ghgi_year
-        helper_flow: None
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
       aviation_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
-        names:
-            - "Aviation Gasoline Transportation"
-        allocation_flow: ['Aviation Gasoline']
       jet_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:jet_transport
         <<: *transport_direct
-        names:
-            - "Jet Fuel Transportation"
-        allocation_flow: ['Jet Fuel']
       lpg_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:lpg_transport
         <<: *transport_direct
-        names:
-            - "LPG (Propane) Transportation"
-        allocation_flow: ['LPG']
       rfo_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:rfo_transport
         <<: *transport_direct
-        names:
-            - "Residual Fuel Transportation"
       dfo_transport: &transport_use
-        names:
-            - "Distillate Fuel Oil Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:dfo_transport
         allocation_source_year: *ghgi_year
-        allocation_flow: ['Distillate Fuel Oil']
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
-        clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
-        helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        helper_activity_to_sector_mapping: "BEA_2012_Detail"
-        helper_method: proportional
-        helper_source_class: "Money"
-        helper_source_year: 2012
-        helper_flow: ["USD2012"]
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
-        clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
       gasoline_transport:
+        !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:gasoline_transport
         <<: *transport_use
-        names:
-            - "Motor Gasoline Transportation"
-        allocation_flow: ['Motor Gasoline']
 
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
-    !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
     activity_sets:
-      !include:GHG_national_2016_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
+      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-        <<: *fuel_MECS
-        names:
-            - "Coal Industrial - Manufacturing"
-        allocation_flow:
-            - "Coal"
+       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year
       ng_manufacturing: # Industrial
-        <<: *fuel_MECS
-        names:
-            - "Natural Gas Industrial - Manufacturing"
-        allocation_flow:
-            - "Natural Gas"
-
-  "EPA_GHGI_T_3_22": #Fossil fuel for non-energy uses
-      data_format: 'FBA'
-      class: Chemicals
-      geoscale_to_use: national
-      year: *ghgi_year
-      fedefl_mapping: 'GHGI'
-      activity_sets:
-        coal:
-          names:
-            - "Industry Industrial Coking Coal"
-            - "Industry Industrial Other Coal"
-          allocation_method: direct
-          allocation_from_scale: national
-        petroleum: # consumed petroleum products
-          <<: *fuel_MECS
-          names:
-            - "Industry Asphalt & Road Oil"
-            - "Industry Distillate Fuel Oil"
-            - "Industry HGL"
-            - "Industry Lubricants"
-            - "Industry Miscellaneous Products"
-            - "Industry Naphtha (<401 F)"
-            - "Industry Other Oil (>401 F)"
-            - "Industry Natural Gasoline"
-            - "Industry Petroleum Coke"
-            - "Industry Special Naphtha"
-            - "Industry Still Gas"
-            - "Industry Waxes"
-          allocation_source: "EIA_MECS_Energy"
-          allocation_source_class: "Other" # nonfuel consumption
-          allocation_flow:
-            - "Other" # consistent with original, but other flows may be better
-        natural_gas: # consumed nat gas to chemical plants
-          <<: *fuel_MECS
-          names:
-            - "Industry Natural Gas to Chemical Plants"
-          allocation_source: "EIA_MECS_Energy"
-          allocation_source_class: "Other" # nonfuel consumption
-          allocation_flow:
-            - "Natural Gas"
-        transport_lubricants:
-          <<: *use_allocation
-          names:
-            - "Transportation Lubricants"
-          clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
+        allocation_source_year: *mecs_year
+        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
@@ -15,7 +15,7 @@ source_names:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
         allocation_source_year: 2019  # latest year
   "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
-    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
+    !include: GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year
   "EPA_GHGI_T_3_70": #CO2 from Natural Gas Systems mimics CH4
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_70
@@ -74,17 +74,17 @@ source_names:
   "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_4_86
     year: *ghgi_year
-  "EPA_GHGI_T_3_22b": #Fossil fuel for non-energy uses
-    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b
+  "EPA_GHGI_T_3_22": #Fossil fuel for non-energy uses
+    !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions
     year: *ghgi_year
     activity_sets: # Update EIA_MECS year for some activity_sets
-      !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets
+      !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:petroleum
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
         allocation_source_year: &mecs_year 2018
         helper_source_year: *mecs_year
       natural_gas:
-        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_22b:activity_sets:natural_gas
+        !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
         helper_source_year: *mecs_year
 

--- a/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
@@ -5,10 +5,18 @@
 # CoA year is 2017
 
 !include:GHG_national_m1.yaml
+ghgi_year: &ghgi_year 2020
+mecs_year: &mecs_year 2018
+
+_industrial_allocation_dict: &industrial_dict
+    energy_fba: 'EIA_MECS_Energy'
+    year: *mecs_year
+    ghg_fba: 'EPA_GHGI_T_A_7' # 2018 Table
+
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1
-    year: &ghgi_year 2020
+    year: *ghgi_year
     activity_sets: # Update USGS year for these activity_sets
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
@@ -81,32 +89,28 @@ source_names:
       !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets
       petroleum:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:petroleum
-        allocation_source_year: &mecs_year 2018
-        helper_source_year: *mecs_year
+        allocation_source_year: *mecs_year
       natural_gas:
         !include:GHG_national_m1.yaml:source_names:GHGI_nonenergy_fossil_fuel_emissions:activity_sets:natural_gas
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
 ## Major CO2 Sources
   "EPA_GHGI_T_A_5":  # CO2 emissions from stationary combustion and transportation. This table number varies by GHG year.
     !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets: # Update EIA_MECS year for some activity_sets
       !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:natural_gas_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
     ### Transportation
       ng_transport: &transport_direct
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:ng_transport
         allocation_source_year: *ghgi_year
-        helper_source_year: *ghgi_year
       aviation_transport:
         !include:GHG_national_m1.yaml:source_names:GHGI_CO2_stationary_combustion_and_transport:activity_sets:aviation_transport
         <<: *transport_direct
@@ -129,27 +133,25 @@ source_names:
   "EPA_GHGI_T_3_8": # CH4 emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
       coal_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_8:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
 
   "EPA_GHGI_T_3_9": # N2O emissions from stationary combustion
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9
     year: *ghgi_year
+    clean_parameter: *industrial_dict
     activity_sets:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets
       coal_manufacturing:
-       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
+        !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:coal_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year
-      ng_manufacturing: # Industrial
+      ng_manufacturing:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_9:activity_sets:ng_manufacturing
         allocation_source_year: *mecs_year
-        helper_source_year: *mecs_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
@@ -13,9 +13,9 @@ source_names:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
-        allocation_source_year: 2019  # latest year
+        allocation_source_year: 2019 # latest year
   "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
-    !include: GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
+    !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year
   "EPA_GHGI_T_3_70": #CO2 from Natural Gas Systems mimics CH4
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_70

--- a/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_2020_m1.yaml
@@ -13,7 +13,7 @@ source_names:
       !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
       lead:
         !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_2_1:activity_sets:lead
-        allocation_source_year: *ghgi_year
+        allocation_source_year: 2019  # latest year
   "EPA_GHGI_T_3_68": #CH4 from Natural Gas Systems
     !include:GHG_national_m1.yaml:source_names:EPA_GHGI_T_3_68
     year: *ghgi_year

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -428,6 +428,7 @@ source_names:
         allocation_flow: ['Natural Gas']
         allocation_compartment: None
         allocation_from_scale: national
+        activity_to_sector_aggregation_level: disaggregated
       aviation_transport:
         <<: *transport_direct
         names:

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -115,6 +115,26 @@ _allocation_types:
     allocation_compartment: None
     allocation_from_scale: national
 
+  _transport_energy_use_allocation: &transport_energy_use_allocation
+    allocation_method: proportional
+    allocation_source: "EPA_GHGI_T_A_73" #Energy consumption by source and transport type
+    allocation_source_class: "Energy"
+    #allocation_source_year: # override with ghgi_year
+    # allocation_flow: # override with activity name, e.g.  ['Distillate Fuel Oil']
+    allocation_compartment: None
+    allocation_from_scale: national
+    clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
+    clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
+    helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
+    helper_activity_to_sector_mapping: "BEA_2012_Detail"
+    helper_method: proportional
+    helper_source_class: "Money"
+    helper_source_year: 2012
+    helper_flow: ["USD2012"]
+    helper_from_scale: national
+    clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
+    clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
+
 source_names:
   "EPA_GHGI_T_2_1": #U.S. GHG emissions
     data_format: 'FBA'
@@ -454,29 +474,14 @@ source_names:
         names:
             - "Residual Fuel Transportation"
         allocation_flow: ['Residual Fuel Oil']
-      dfo_transport: &transport_use
+      dfo_transport:
+        <<: *transport_energy_use_allocation
         names:
             - "Distillate Fuel Oil Transportation"
-        allocation_method: proportional
-        allocation_source: "EPA_GHGI_T_A_73"
-        allocation_source_class: "Energy"
         #allocation_source_year: # override with ghgi_year
         allocation_flow: ['Distillate Fuel Oil']
-        allocation_compartment: None
-        allocation_from_scale: national
-        clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
-        clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
-        helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
-        helper_activity_to_sector_mapping: "BEA_2012_Detail"
-        helper_method: proportional
-        helper_source_class: "Money"
-        helper_source_year: 2012
-        helper_flow: ["USD2012"]
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
-        clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
       gasoline_transport:
-        <<: *transport_use
+        <<: *transport_energy_use_allocation
         names:
             - "Motor Gasoline Transportation"
         allocation_flow: ['Motor Gasoline']

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -113,7 +113,7 @@ _allocation_types:
     helper_source_year: 2012
     helper_flow: ["USD2012"]
     helper_from_scale: national
-    clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
+    clean_helper_fba_wsec: !script_function:BEA subset_BEA_table
     clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
 
 source_names:

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -308,26 +308,6 @@ source_names:
         clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
       grassland: *grassland # allocated based on USDA Animal operation land (acres)
 
-## Mobile Sources
-  # "EPA_GHGI_T_3_13": #CO2 from mobile combustion
-  #   data_format: 'FBA'
-  #   class: Chemicals
-  #   geoscale_to_use: national
-  #   year: *ghgi_year
-  #   fedefl_mapping: 'GHGI'
-  #   activity_sets:
-  #     activity_set_1:  #this set is direct
-  #       names:
-  #           - "Pipeline Natural Gas"
-  #           - "General Aviation Aircraft Aviation Gasoline"
-  #           - "General Aviation Aircraft Jet Fuel"
-  #           - "Commercial Aircraft Jet Fuel"
-  #           - "Military Aircraft Jet Fuel"
-  #           - "Ships and Non-Recreational Boats Residual Fuel Oil"
-  #       allocation_method: direct
-  #       allocation_source: None
-  #       allocation_from_scale: national
-
   "EPA_GHGI_T_3_14": &mobile #CH4 from mobile combustion
     data_format: 'FBA'
     class: Chemicals

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -1,0 +1,707 @@
+# This is the general method reference file
+# Year-specific GHG_national_m1 files import this file to define attribution rules
+# that are further customized
+# m1 for the GHG national largely replicates the method used in the National GHG
+# Industry Attribution Model (v1) (https://doi.org/10.23719/1517571), except that
+# sector attribution is to 6-digit NAICS, rather than the BEA 2012 IO schema
+# Allocation source years for BEA Use/Make and Census of Ag (CoA) are currently fixed at 2012 and 2017, respectively
+# other allocation source years including MECS is not defined here
+target_sector_level: NAICS_6
+target_sector_source: NAICS_2012_Code
+target_geoscale: national
+
+_allocation_types:
+  _mecs_allocation: &fuel_MECS
+    # names: # override this
+    allocation_source: "EIA_MECS_Energy"
+    allocation_method: proportional
+    allocation_source_class: "Energy"
+    # allocation_source_year:  # override this
+    # allocation_flow:  # override this
+    #   - "Coal"
+    allocation_compartment: None
+    allocation_from_scale: national
+    allocation_selection_fields:
+        Description:
+            - "Table 2.2"  # Nonfuel (class Other)
+            - "Table 3.2"  # Fuel (class Energy)
+    clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
+    clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
+    helper_source: "BLS_QCEW"
+    helper_method: proportional-flagged
+    helper_source_class: "Employment"
+    # helper_source_year: # override this
+    helper_flow: None
+    helper_from_scale: national
+    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+
+  _use_allocation: &use_allocation
+    # names: # override this
+    allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
+    activity_to_sector_mapping: "BEA_2012_Detail"
+    allocation_method: proportional
+    allocation_source_class: "Money"
+    allocation_source_year: 2012
+    allocation_flow:
+      - "USD2012"
+    allocation_compartment: None
+    allocation_from_scale: national
+    clean_allocation_fba: !script_function:BEA subset_BEA_table
+    # clean_parameter: # override this with dictionary like {"324110": 'ActivityProducedBy'}
+    helper_source: "BLS_QCEW"
+    helper_method: proportional
+    helper_source_class: "Employment"
+    helper_source_year: 2012
+    helper_flow: None
+    helper_from_scale: national
+    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+
+  _make_allocation: &make_allocation
+    #names: # override this
+    allocation_method: proportional
+    allocation_source: "BEA_Make_Detail_BeforeRedef"
+    activity_to_sector_mapping: "BEA_2012_Detail"
+    allocation_source_class: "Money"
+    allocation_source_year: 2012
+    allocation_flow:
+      - "USD2012"
+    allocation_compartment: None
+    allocation_from_scale: national
+    clean_allocation_fba: !script_function:BEA subset_BEA_table
+    # clean_parameter: # over ride this with dictionary, like {"221100": 'ActivityConsumedBy'} # Electricity
+    helper_source: "BLS_QCEW"
+    helper_method: proportional
+    helper_source_class: "Employment"
+    helper_source_year: 2012
+    helper_from_scale: national
+    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+
+  _lead_allocation: &lead_allocation
+    names:
+    - "Lead Production" #CO2
+    allocation_method: proportional
+    allocation_source: "USGS_MYB_Lead"
+    allocation_source_class: "Geological"
+    #allocation_source_year: #override this
+    allocation_compartment: None
+    allocation_from_scale: national
+
+  _cropland_allocation: &cropland_allocation
+    names:
+        - "Mineralization and Asymbiotic Fixation Cropland"
+        - "Drained Organic Soils Cropland"
+    allocation_source: "USDA_CoA_Cropland"
+    allocation_method: proportional
+    allocation_source_class: "Land"
+    # allocation_source_year: #override this 2017
+    allocation_flow:
+      - "AREA HARVESTED"
+      - "AREA BEARING & NON-BEARING" # Orchards
+      - "AREA GROWN" # Berry totals
+      - "AREA IN PRODUCTION" # Vegetable totals
+    allocation_compartment: None
+    allocation_from_scale: national
+    clean_allocation_fba_w_sec: !script_function:USDA_CoA_Cropland disaggregate_coa_cropland_to_6_digit_naics
+
+  _animal_land_allocation: &animal_land_allocation
+    names:
+        - "All activities Grassland"
+    allocation_method: proportional
+    allocation_source: "USDA_CoA_Cropland_NAICS"
+    allocation_source_class: "Land"
+    #allocation_source_year: #override this
+    allocation_flow:
+      - "FARM OPERATIONS"
+    allocation_compartment: None
+    allocation_from_scale: national
+
+source_names:
+  "EPA_GHGI_T_2_1": #U.S. GHG emissions
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      direct:
+        names:
+          - "Iron and Steel Production & Metallurgical Coke Production" #CO2, CH4
+          - "Cement Production" #CO2
+          - "Lime Production" #CO2
+          - "Ammonia Production" #CO2
+          - "Incineration of Waste" #CO2, #N2O
+          - "Aluminum Production" #CO2
+          - "Soda Ash Production" #CO2
+          - "Ferroalloy Production" #CO2, CH4
+          - "Titanium Dioxide Production" #CO2
+          - "Zinc Production" #CO2
+          - "Phosphoric Acid Production" #CO2
+          - "Glass Production" #CO2
+          - "Carbide Production and Consumption" #CO2, CH4
+          - "Landfills" #CH4
+          - "Coal Mining" #CO2, CH4
+          - "Wastewater Treatment" #CH4, N2O
+          - "Rice Cultivation" #CH4
+          - "Abandoned Oil and Gas Wells" #CH4
+          - "Abandoned Underground Coal Mines" #CH4
+          - "Anaerobic Digestion at Biogas Facilities" #CH4 new activity
+          - "Composting" #CH4, N2O
+          - "Nitric Acid Production" #N2O
+          - "Adipic Acid Production" #N2O
+          - "Caprolactam, Glyoxal, and Glyoxylic Acid Production" #N2O
+        source_flows: ["CO2", "CH4", "N2O"] # HFCs and other flows are pulled elsewhere
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+      electricity_transmission:
+        names:
+          - "Electrical Transmission and Distribution" #SF6
+        source_flows: ["SF6"]
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+      electric_power:
+        <<: *make_allocation
+        names:
+        - "Electric Power Sector" #CO2
+        clean_parameter: {"221100": 'ActivityConsumedBy'} # Electricity
+      liming:
+        <<: *use_allocation
+        names:
+        - "Liming"  #CO2
+        clean_parameter: {"327400": 'ActivityProducedBy'} # Lime
+      urea:
+        <<: *use_allocation
+        names:
+        - "Urea Fertilization" #CO2
+        - "Urea Consumption for Non-Agricultural Purposes" #CO2
+        clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
+      carbonates:
+        <<: *use_allocation
+        names:
+        - "Other Process Uses of Carbonates" #CO2
+        clean_parameter: {"325180": 'ActivityProducedBy'} # Other Basic Inorganic Chemicals
+      lead:
+        <<: *lead_allocation
+      N2O_products:
+        <<: *use_allocation
+        names:
+        - "N2O from Product Uses" #N2O
+        clean_parameter: {"325120": 'ActivityProducedBy'} # Industrial gases
+
+## Fossil Fuels
+  "EPA_GHGI_T_3_68": &natgas #CH4 from Natural Gas Systems
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      nat_gas:
+        names:
+          - "Distribution"
+          - "Distribution - Post-Meter"
+          - "Exploration"
+          - "Processing"
+          - "Production"
+          - "Transmission and Storage"
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+  "EPA_GHGI_T_3_70": *natgas #CO2 from Natural Gas Systems mimics CH4
+  "EPA_GHGI_T_3_72": *natgas #N2O from Natural Gas Systems, not used in original method, mimics CH4
+  "EPA_GHGI_T_3_42": &petroleum #CH4 from Petroleum Systems
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      petroleum:
+        names:
+          - "Crude Oil Transportation"
+          - "Exploration"
+          - "Production"
+          - "Refining"
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+  "EPA_GHGI_T_3_44": *petroleum #CO2 from Petroleum Systems mimics CH4
+  "EPA_GHGI_T_3_46": *petroleum #N2O from Petroleum Systems, not in prior method, mimics CH4
+
+## Agriculture
+  "EPA_GHGI_T_5_28": #CH4, N2O, CO and NOx from field burning of residues
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override this
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        crops:
+          names:
+            - "Chickpeas"
+            - "Cotton"
+            - "Maize"
+            - "Rice"
+            - "Soybeans"
+            - "Wheat"
+          allocation_method: direct
+          allocation_source: None
+          allocation_from_scale: national
+  "EPA_GHGI_T_5_3":  &animals #CH4 from Enteric Fermentation
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      animals:
+        names:
+          - "American Bison"
+          - "Beef Cattle"
+          - "Dairy Cattle"
+          - "Goats"
+          - "Horses"
+          - "Mules and Asses"
+          - "Sheep"
+          - "Swine"
+          - "Poultry"
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+  "EPA_GHGI_T_5_6": *animals #CH4 and N2O from manure, mimics enteric fermentation
+
+  "EPA_GHGI_T_5_17": #Direct N2O emissions from agricultural soils
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      fertilizer_use:  # allocated based on fertilizer use
+        <<: *use_allocation
+        names:
+            - "Organic Amendment Cropland"
+            - "Residue N Cropland"
+            - "Synthetic Fertilizer Cropland"
+        clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
+      land_area:
+        <<: *cropland_allocation
+        allocation_source_year: 2017
+      grassland: &grassland
+        <<: *animal_land_allocation
+        allocation_source_year: 2017
+
+  "EPA_GHGI_T_5_18": #Indirect N2O emissions from agricultural soils
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      fertilizer_use:  # allocated based on fertilizer use
+        <<: *use_allocation
+        names:
+            - "Volatilization & Atm. Deposition Cropland"
+            - "Surface Leaching & Run-Off Cropland"
+        clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
+      grassland: *grassland # allocated based on USDA Animal operation land (acres)
+
+## Mobile Sources
+  # "EPA_GHGI_T_3_13": #CO2 from mobile combustion
+  #   data_format: 'FBA'
+  #   class: Chemicals
+  #   geoscale_to_use: national
+  #   year: *ghgi_year
+  #   fedefl_mapping: 'GHGI'
+  #   activity_sets:
+  #     activity_set_1:  #this set is direct
+  #       names:
+  #           - "Pipeline Natural Gas"
+  #           - "General Aviation Aircraft Aviation Gasoline"
+  #           - "General Aviation Aircraft Jet Fuel"
+  #           - "Commercial Aircraft Jet Fuel"
+  #           - "Military Aircraft Jet Fuel"
+  #           - "Ships and Non-Recreational Boats Residual Fuel Oil"
+  #       allocation_method: direct
+  #       allocation_source: None
+  #       allocation_from_scale: national
+
+  "EPA_GHGI_T_3_14": &mobile #CH4 from mobile combustion
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      direct:  #this set is direct
+        names:
+            - "Passenger Cars Gasoline On-Road"
+            - "Passenger Cars Diesel On-Road"
+            - "Light-Duty Trucks Gasoline On-Road"
+            - "Rail Non-Road"
+            - "Ships and Boats Non-Road"
+            - "Aircraft Non-Road"
+            - "Light-Duty Trucks Diesel On-Road"
+            - "Medium- and Heavy-Duty Trucks Diesel On-Road"
+            - "Medium- and Heavy-Duty Buses Diesel On-Road"
+            - "Medium- and Heavy-Duty Trucks and Buses Gasoline On-Road"
+            - "Motorcycles Gasoline On-Road"
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+      construction: #this set is allocated by purchases of construction equipment
+        <<: *use_allocation
+        names:
+          - "Construction/Mining Equipment Non-Road"
+        clean_parameter: {"333120": 'ActivityProducedBy'} # purchases of construction equipment
+      ag: #this set is allocated by purchases of farm machinery
+        <<: *use_allocation
+        names:
+          - "Agricultural Equipment Non-Road"
+        clean_parameter: {"333111": 'ActivityProducedBy'} # purchases of farm machinery
+      other_non_road: #this set is allocated by purchases of petroleum refining
+        <<: *use_allocation
+        names:
+          - "Other Non-Road"
+        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery products
+      alternatives: #this set is allocated by purchases of natural gas
+        <<: *use_allocation
+        names:
+          - "Alternative Fuel On-Road"
+        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
+  "EPA_GHGI_T_3_15": *mobile #N2O from mobile combustion duplicates method for CH4
+
+## Major CO2 Sources
+  "GHGI_CO2_stationary_combustion_and_transport": # CO2 emissions from stationary combustion and transportation
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: # override this
+    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      direct:
+        names:
+            - "Total (All Fuels) Residential"
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+      coal:
+        <<: *use_allocation
+        names:
+            - "Commercial Coal Commercial"
+            - "Industrial Other Coal Industrial"
+        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
+      natural_gas:
+        <<: *use_allocation
+        names:
+            - "Natural Gas Commercial"
+            - "Natural Gas Industrial"
+        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
+      petroleum:
+        <<: *use_allocation
+        names:
+            - "Total Petroleum Commercial"
+            - "Total Petroleum Industrial"
+        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
+      coal_manufacturing:
+        <<: *fuel_MECS
+        names:
+            - "Industrial Other Coal Industrial - Manufacturing"
+        allocation_flow:
+            - "Coal"
+      natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
+        <<: *fuel_MECS
+        names:
+            - "Natural Gas Industrial - Manufacturing"
+        allocation_flow:
+            - "Natural Gas"
+    ### Transportation
+      ng_transport: &transport_direct
+        names:
+            - "Natural Gas Transportation"
+        allocation_method: proportional
+        allocation_source: "EPA_GHGI_T_A_73"
+        allocation_source_class: "Energy"
+        # allocation_source_year: *ghgi_year
+        allocation_flow: ['Natural Gas']
+        allocation_compartment: None
+        allocation_from_scale: national
+        helper_source: "BLS_QCEW"
+        helper_method: proportional
+        helper_source_class: "Employment"
+        # helper_source_year: *ghgi_year
+        helper_from_scale: national
+        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
+      aviation_transport:
+        <<: *transport_direct
+        names:
+            - "Aviation Gasoline Transportation"
+        allocation_flow: ['Aviation Gasoline']
+      jet_transport:
+        <<: *transport_direct
+        names:
+            - "Jet Fuel Transportation"
+        allocation_flow: ['Jet Fuel']
+      lpg_transport:
+        <<: *transport_direct
+        names:
+            - "LPG (Propane) Transportation"
+        allocation_flow: ['LPG']
+      rfo_transport:
+        <<: *transport_direct
+        names:
+            - "Residual Fuel Transportation"
+        allocation_flow: ['Residual Fuel Oil']
+      dfo_transport: &transport_use
+        names:
+            - "Distillate Fuel Oil Transportation"
+        allocation_method: proportional
+        allocation_source: "EPA_GHGI_T_A_73"
+        allocation_source_class: "Energy"
+        #allocation_source_year: # override with ghgi_year
+        allocation_flow: ['Distillate Fuel Oil']
+        allocation_compartment: None
+        allocation_from_scale: national
+        clean_allocation_fba: !script_function:EPA_GHGI adjust_transport_activities
+        clean_allocation_fba_w_sec: !script_function:EPA_GHGI keep_six_digit_naics
+        helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
+        helper_activity_to_sector_mapping: "BEA_2012_Detail"
+        helper_method: proportional
+        helper_source_class: "Money"
+        helper_source_year: 2012
+        helper_flow: ["USD2012"]
+        helper_from_scale: national
+        clean_helper_fba_wsec: !script_function:BEA subset_and_allocate_BEA_table
+        clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
+      gasoline_transport:
+        <<: *transport_use
+        names:
+            - "Motor Gasoline Transportation"
+        allocation_flow: ['Motor Gasoline']
+
+## Stationary Combustion
+  "EPA_GHGI_T_3_8":  &stationary_combustion # CH4 emissions from stationary combustion
+    data_format: 'FBA'
+    class: Chemicals
+    geoscale_to_use: national
+    #year: #override this with ghgi_year
+    clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
+    fedefl_mapping: 'GHGI'
+    activity_sets:
+      residential:
+        names:
+            - "Fuel Oil Residential"
+            - "Coal Residential"
+            - "Natural Gas Residential"
+            - "Wood Residential"
+        allocation_method: direct
+        allocation_source: None
+        allocation_from_scale: national
+      electric_power:
+        <<: *make_allocation
+        names:
+            - "Coal Electric Power"
+            - "Natural Gas Electric Power"
+            - "Fuel Oil Electric Power"
+            - "Wood Electric Power"
+        clean_parameter: {"221100": 'ActivityConsumedBy'} # Electricity
+      fuel_oil:
+        <<: *use_allocation
+        names:
+            - "Fuel Oil Commercial"
+            - "Fuel Oil Industrial"
+        clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
+      natural_gas: # Commercial Natural gas
+        <<: *use_allocation
+        names:
+            - "Natural Gas Commercial"
+            - "Natural Gas Industrial"
+        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
+      coal:
+        <<: *use_allocation
+        names:
+            - "Coal Industrial"
+        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
+      coal_manufacturing: # Industrial
+        <<: *fuel_MECS
+        names:
+            - "Coal Industrial - Manufacturing"
+        allocation_flow:
+            - "Coal"
+      ng_manufacturing: # Industrial
+        <<: *fuel_MECS
+        names:
+            - "Natural Gas Industrial - Manufacturing"
+        allocation_flow:
+            - "Natural Gas"
+
+    ## TODO MISSING 'Wood Commercial' and 'Wood Industrial'
+
+  "EPA_GHGI_T_3_9":
+      <<: *stationary_combustion # N2O emissions from stationary combustion
+
+## Other sources
+  "EPA_GHGI_T_4_46": #CO2 for selected petrochemicals
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override with ghgi_year
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        direct:
+          names:
+            - "Acrylonitrile"
+            - "Carbon Black"
+            - "Ethylene"
+            - "Ethylene Dichloride"
+            - "Ethylene Oxide"
+            - "Methanol"
+          allocation_method: direct
+          allocation_source: None
+          allocation_from_scale: national
+  "EPA_GHGI_T_3_22b": # Fossil fuel for non-energy uses
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: #override with ghgi_year
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        coal:
+          names:
+            - "Industry Industrial Coking Coal"
+            - "Industry Industrial Other Coal"
+          allocation_method: direct
+          allocation_from_scale: national
+        petroleum:
+          <<: *fuel_MECS
+          names:
+            - "Industry Asphalt & Road Oil"
+            - "Industry Distillate Fuel Oil"
+            - "Industry LPG"
+            - "Industry Lubricants"
+            - "Industry Miscellaneous Products"
+            - "Industry Naphtha (<401 F)"
+            - "Industry Other Oil (>401 F)"
+            - "Industry Pentanes Plus"
+            - "Industry Petroleum Coke"
+            - "Industry Special Naphtha"
+            - "Industry Still Gas"
+            - "Industry Waxes"
+          allocation_source: "EIA_MECS_Energy"
+          allocation_source_class: "Other" # nonfuel consumption
+          allocation_flow:
+            - "Other" # consistent with original, but other flows may be better
+        natural_gas: # consumed nat gas to chemical plants
+          <<: *fuel_MECS
+          names:
+            - "Industry Natural Gas to Chemical Plants"
+          allocation_source: "EIA_MECS_Energy"
+          allocation_source_class: "Other" # nonfuel consumption
+          allocation_flow:
+            - "Natural Gas"
+        transport_lubricants:
+          <<: *use_allocation
+          names:
+            - "Transportation Lubricants"
+          clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
+
+## Other Emissions
+  "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override with ghgi_year
+      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI remove_HFC_kt
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        direct:
+          names:
+            - "HCFC-22 Production"
+          allocation_method: direct
+          allocation_from_scale: national
+  "EPA_GHGI_T_4_96": # HFCs and other emissions from electronics manufacture
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override with ghgi_year
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        direct:
+          names:
+            - "Electronics Production"
+          allocation_method: direct
+          allocation_from_scale: national
+  "EPA_GHGI_T_4_102": # HFCs and PFCs from ODS Substitutes
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override with ghgi_year
+      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI clean_HFC_fba # removes HFCs from transportation
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        households:
+          names:
+            - "Refrigeration/Air Conditioning - Households"
+          allocation_method: direct
+          allocation_from_scale: national
+        refrigerants:
+          <<: *use_allocation
+          names:
+            - "Refrigeration/Air Conditioning"
+          clean_parameter: {"333415": 'ActivityProducedBy'} # Air conditioning equipment
+        foams_polystyrene:
+          <<: *use_allocation
+          names:
+            - "Foams - Polystyrene"
+          clean_parameter: {"326140": 'ActivityProducedBy'} # Polystyrene foam
+        foams_urethane:
+          <<: *use_allocation
+          names:
+            - "Foams - Urethane"
+          clean_parameter: {"326150": 'ActivityProducedBy'} # Urethane and other foam
+  "EPA_GHGI_T_A_97": # HFCs from Transportation
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override with ghgi_year
+      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI split_HFCs_by_type
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        direct:
+          names:
+            - "Mobile AC - Passenger Cars"
+            - "Mobile AC - Heavy-Duty Vehicles"
+            - "Mobile AC - Light-Duty Trucks"
+            - "Comfort Cooling for Trains and Buses - School and Tour Buses"
+            - "Comfort Cooling for Trains and Buses - Rail"
+            - "Refrigerated Transport - Medium- and Heavy-Duty Trucks"
+            - "Refrigerated Transport - Rail"
+            - "Refrigerated Transport - Ships and Boats"
+          allocation_method: direct
+          allocation_from_scale: national
+  "EPA_GHGI_T_4_80": # PFCs from aluminum production
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override with ghgi_year
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        aluminum:
+          names:
+            - "Aluminum Production"
+          allocation_method: direct
+          allocation_from_scale: national
+  "EPA_GHGI_T_4_86": # HFCs, SF6, CO2 from magnesium production
+      data_format: 'FBA'
+      class: Chemicals
+      geoscale_to_use: national
+      #year: # override with ghgi_year
+      fedefl_mapping: 'GHGI'
+      activity_sets:
+        magnesium:
+            <<: *make_allocation # Make table allocation
+            names:
+            - "Magnesium Production and Processing"
+            clean_parameter: {"T008": 'ActivityConsumedBy'} # Gross Output

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -557,7 +557,7 @@ source_names:
           allocation_from_scale: national
         petroleum:
           <<: *fuel_MECS
-          names:
+          names: #Flows are from T_3_22b except where noted, as they change in T_3_22 post 2019
             - "Industry Asphalt & Road Oil"
             - "Industry Distillate Fuel Oil"
             - "Industry LPG"
@@ -565,11 +565,13 @@ source_names:
             - "Industry Miscellaneous Products"
             - "Industry Naphtha (<401 F)"
             - "Industry Other Oil (>401 F)"
-            - "Industry Pentanes Plus"
             - "Industry Petroleum Coke"
             - "Industry Special Naphtha"
             - "Industry Still Gas"
             - "Industry Waxes"
+            - "Industry Pentanes Plus"
+            - "Industry Natural Gasoline" #T_3_22. Also produced by nat gas plants
+            - "Industry HGL" #T_3_22. Also produced by nat gas plants
           allocation_source: "EIA_MECS_Energy"
           allocation_source_class: "Other" # nonfuel consumption
           allocation_flow:
@@ -588,7 +590,7 @@ source_names:
             - "Transportation Lubricants"
           clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
 
-## Other Emissions
+### Other Emissions
   "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
       data_format: 'FBA'
       class: Chemicals

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -40,7 +40,7 @@ _allocation_types:
       - "USD2012"
     allocation_compartment: None
     allocation_from_scale: national
-    clean_allocation_fba: !script_function:BEA subset_BEA_table
+    clean_allocation_fba: !script_function:BEA subset_and_equally_allocate_BEA_table
     # clean_parameter: # override this with dictionary like {"324110": 'ActivityProducedBy'}
 
   _make_allocation: &make_allocation
@@ -54,7 +54,7 @@ _allocation_types:
       - "USD2012"
     allocation_compartment: None
     allocation_from_scale: national
-    clean_allocation_fba: !script_function:BEA subset_BEA_table
+    clean_allocation_fba: !script_function:BEA subset_and_equally_allocate_BEA_table
     # clean_parameter: # over ride this with dictionary, like {"221100": 'ActivityConsumedBy'} # Electricity
 
   _lead_allocation: &lead_allocation
@@ -113,7 +113,7 @@ _allocation_types:
     helper_source_year: 2012
     helper_flow: ["USD2012"]
     helper_from_scale: national
-    clean_helper_fba_wsec: !script_function:BEA subset_BEA_table
+    clean_helper_fba_wsec: !script_function:BEA subset_and_equally_allocate_BEA_table
     clean_parameter: {"324110": 'ActivityProducedBy'} # use of petroleum products
 
 source_names:

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -25,8 +25,9 @@ _allocation_types:
         Description:
             - "Table 2.2"  # Nonfuel (class Other)
             - "Table 3.2"  # Fuel (class Energy)
-    clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
-    clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
+        Unit:
+            - "MJ"
+    clean_allocation_fba_w_sec: !script_function:EIA_MECS mecs_energy_equally_attribute
 
   _use_allocation: &use_allocation
     # names: # override this

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -542,7 +542,7 @@ source_names:
           allocation_method: direct
           allocation_source: None
           allocation_from_scale: national
-  "EPA_GHGI_T_3_22b": # Fossil fuel for non-energy uses
+  "GHGI_nonenergy_fossil_fuel_emissions": # Fossil fuel for non-energy uses
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -40,7 +40,7 @@ _allocation_types:
       - "USD2012"
     allocation_compartment: None
     allocation_from_scale: national
-    clean_allocation_fba: !script_function:BEA subset_and_equally_allocate_BEA_table
+    clean_allocation_fba_w_sec: !script_function:BEA subset_and_equally_allocate_BEA_table
     # clean_parameter: # override this with dictionary like {"324110": 'ActivityProducedBy'}
 
   _make_allocation: &make_allocation
@@ -54,7 +54,7 @@ _allocation_types:
       - "USD2012"
     allocation_compartment: None
     allocation_from_scale: national
-    clean_allocation_fba: !script_function:BEA subset_and_equally_allocate_BEA_table
+    clean_allocation_fba_w_sec: !script_function:BEA subset_and_equally_allocate_BEA_table
     # clean_parameter: # over ride this with dictionary, like {"221100": 'ActivityConsumedBy'} # Electricity
 
   _lead_allocation: &lead_allocation

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -15,11 +15,10 @@ _allocation_types:
     # names: # override this
     allocation_source: "EIA_MECS_Energy"
     allocation_method: proportional
-    allocation_source_class: "Energy"
-    # allocation_source_year:  # override this
+    # allocation_source_class: "Energy" #override this
+    # allocation_source_year: *mecs_year # override this with mecs year
     # allocation_flow:  # override this
     #   - "Coal"
-    allocation_compartment: None
     allocation_from_scale: national
     allocation_selection_fields:
         Description:
@@ -27,10 +26,20 @@ _allocation_types:
             - "Table 3.2"  # Fuel (class Energy)
         Unit:
             - "MJ"
-    clean_allocation_fba_w_sec: !script_function:EIA_MECS mecs_energy_equally_attribute
+    clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
+    helper_source: "BEA_Use_Detail_PRO_BeforeRedef"
+    helper_activity_to_sector_mapping: "BEA_2012_Detail"
+    helper_method: proportional-flagged
+    helper_source_class: "Money"
+    helper_source_year: 2012
+    helper_flow:
+      - "USD2012"
+    helper_from_scale: national
+    clean_helper_fba_wsec: !script_function:BEA subset_and_equally_allocate_BEA_table
+    # clean_parameter: # override this with dictionary like {"324110": 'ActivityProducedBy'}
 
   _use_allocation: &use_allocation
-    # names: # override this
+    # names:  # override this
     allocation_source: "BEA_Use_Detail_PRO_BeforeRedef"
     activity_to_sector_mapping: "BEA_2012_Detail"
     allocation_method: proportional
@@ -44,7 +53,7 @@ _allocation_types:
     # clean_parameter: # override this with dictionary like {"324110": 'ActivityProducedBy'}
 
   _make_allocation: &make_allocation
-    #names: # override this
+    # names: # override this
     allocation_method: proportional
     allocation_source: "BEA_Make_Detail_BeforeRedef"
     activity_to_sector_mapping: "BEA_2012_Detail"
@@ -63,7 +72,7 @@ _allocation_types:
     allocation_method: proportional
     allocation_source: "USGS_MYB_Lead"
     allocation_source_class: "Geological"
-    #allocation_source_year: #override this
+    # allocation_source_year: #override this
     allocation_compartment: None
     allocation_from_scale: national
 
@@ -79,8 +88,6 @@ _allocation_types:
       - "AREA HARVESTED"
       - "AREA BEARING & NON-BEARING" # Orchards
       - "AREA GROWN" # Berry totals
-      - "AREA IN PRODUCTION" # Vegetable totals
-    allocation_compartment: None
     allocation_from_scale: national
     clean_allocation_fba_w_sec: !script_function:USDA_CoA_Cropland disaggregate_coa_cropland_to_6_digit_naics
 
@@ -90,7 +97,7 @@ _allocation_types:
     allocation_method: proportional
     allocation_source: "USDA_CoA_Cropland_NAICS"
     allocation_source_class: "Land"
-    #allocation_source_year: #override this
+    # allocation_source_year: #override this
     allocation_flow:
       - "FARM OPERATIONS"
     allocation_compartment: None
@@ -100,7 +107,7 @@ _allocation_types:
     allocation_method: proportional
     allocation_source: "EPA_GHGI_T_A_73" #Energy consumption by source and transport type
     allocation_source_class: "Energy"
-    #allocation_source_year: # override with ghgi_year
+    # allocation_source_year: # override with ghgi_year
     # allocation_flow: # override with activity name, e.g.  ['Distillate Fuel Oil']
     allocation_compartment: None
     allocation_from_scale: national
@@ -121,7 +128,7 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     fedefl_mapping: 'GHGI'
     activity_sets:
       direct:
@@ -195,7 +202,7 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     fedefl_mapping: 'GHGI'
     activity_sets:
       nat_gas:
@@ -215,7 +222,7 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     fedefl_mapping: 'GHGI'
     activity_sets:
       petroleum:
@@ -235,7 +242,7 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override this
+      # year: # override this
       fedefl_mapping: 'GHGI'
       activity_sets:
         crops:
@@ -253,7 +260,7 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     fedefl_mapping: 'GHGI'
     activity_sets:
       animals:
@@ -276,7 +283,7 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     fedefl_mapping: 'GHGI'
     activity_sets:
       fertilizer_use:  # allocated based on fertilizer use
@@ -297,7 +304,7 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     fedefl_mapping: 'GHGI'
     activity_sets:
       fertilizer_use:  # allocated based on fertilizer use
@@ -313,7 +320,7 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     fedefl_mapping: 'GHGI'
     activity_sets:
       direct:  #this set is direct
@@ -359,8 +366,12 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: # override this
+    # year: # override this
     clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
+    # clean_parameter: # Override each year for use in allocate_industrial_combustion
+    #     energy_fba: 'EIA_MECS_Energy'
+    #     year: 2018
+    #     ghg_fba: 'EPA_GHGI_T_A_7' # 2018 Table
     fedefl_mapping: 'GHGI'
     activity_sets:
       direct:
@@ -369,14 +380,14 @@ source_names:
         allocation_method: direct
         allocation_source: None
         allocation_from_scale: national
-      coal:
-        <<: *use_allocation
+      coal_nonmanufacturing:
+        <<: *use_allocation # Applies to non-manufacturing sectors like ag and mining
         names:
             - "Commercial Coal Commercial"
             - "Industrial Other Coal Industrial"
         clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
-      natural_gas:
-        <<: *use_allocation
+      natural_gas_nonmanufacturing:
+        <<: *use_allocation  # Applies to non-manufacturing sectors like ag and mining
         names:
             - "Natural Gas Commercial"
             - "Natural Gas Industrial"
@@ -391,14 +402,19 @@ source_names:
         <<: *fuel_MECS
         names:
             - "Industrial Other Coal Industrial - Manufacturing"
+        allocation_source_class: "Energy" # fuel consumption
         allocation_flow:
-            - "Coal"
+          - "Coal"
+          - "Coke and Breeze"
+        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
       natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
         <<: *fuel_MECS
         names:
             - "Natural Gas Industrial - Manufacturing"
+        allocation_source_class: "Energy" # fuel consumption
         allocation_flow:
             - "Natural Gas"
+        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
     ### Transportation
       ng_transport: &transport_direct
         names:
@@ -435,7 +451,7 @@ source_names:
         <<: *transport_energy_use_allocation
         names:
             - "Distillate Fuel Oil Transportation"
-        #allocation_source_year: # override with ghgi_year
+        # allocation_source_year: # override with ghgi_year
         allocation_flow: ['Distillate Fuel Oil']
       gasoline_transport:
         <<: *transport_energy_use_allocation
@@ -448,8 +464,12 @@ source_names:
     data_format: 'FBA'
     class: Chemicals
     geoscale_to_use: national
-    #year: #override this with ghgi_year
+    # year: #override this with ghgi_year
     clean_fba_df_fxn: !script_function:EPA_GHGI allocate_industrial_combustion
+    # clean_parameter: # Override each year for use in allocate_industrial_combustion
+    #     energy_fba: 'EIA_MECS_Energy'
+    #     year: 2018
+    #     ghg_fba: 'EPA_GHGI_T_A_7' # 2018 Table
     fedefl_mapping: 'GHGI'
     activity_sets:
       residential:
@@ -475,13 +495,13 @@ source_names:
             - "Fuel Oil Commercial"
             - "Fuel Oil Industrial"
         clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
-      natural_gas: # Commercial Natural gas
+      natural_gas_nonmanufacturing: # Commercial Natural gas
         <<: *use_allocation
         names:
             - "Natural Gas Commercial"
             - "Natural Gas Industrial"
         clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
-      coal:
+      coal_nonmanufacturing:
         <<: *use_allocation
         names:
             - "Coal Industrial"
@@ -490,16 +510,20 @@ source_names:
         <<: *fuel_MECS
         names:
             - "Coal Industrial - Manufacturing"
+        allocation_source_class: "Energy" # fuel consumption
         allocation_flow:
             - "Coal"
+        clean_parameter: {"212100": 'ActivityProducedBy'} # purchases of coal
       ng_manufacturing: # Industrial
         <<: *fuel_MECS
         names:
             - "Natural Gas Industrial - Manufacturing"
+        allocation_source_class: "Energy" # fuel consumption
         allocation_flow:
             - "Natural Gas"
+        clean_parameter: {"221200": 'ActivityProducedBy'} # purchases of natural gas
 
-    ##Intentionally left out 'Wood Commercial' and 'Wood Industrial'
+    #Intentionally left out 'Wood Commercial' and 'Wood Industrial'
 
   "EPA_GHGI_T_3_9":
       <<: *stationary_combustion # N2O emissions from stationary combustion
@@ -509,7 +533,7 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override with ghgi_year
+      # year: # override with ghgi_year
       fedefl_mapping: 'GHGI'
       activity_sets:
         direct:
@@ -527,7 +551,7 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: #override with ghgi_year
+      # year: #override with ghgi_year
       fedefl_mapping: 'GHGI'
       activity_sets:
         coal:
@@ -553,30 +577,32 @@ source_names:
             - "Industry Pentanes Plus"
             - "Industry Natural Gasoline" #T_3_22. Also produced by nat gas plants
             - "Industry HGL" #T_3_22. Also produced by nat gas plants
-          allocation_source: "EIA_MECS_Energy"
           allocation_source_class: "Other" # nonfuel consumption
           allocation_flow:
-            - "Other" # consistent with original, but other flows may be better
+            - "Residual Fuel Oil"
+            - "Distillate Fuel Oil"
+            - "Hydrocarbon Gas Liquids, excluding natural gasoline"
+          clean_parameter: {"324110": 'ActivityProducedBy'} # use purchases of petroleum refineries
         natural_gas: # consumed nat gas to chemical plants
           <<: *fuel_MECS
           names:
             - "Industry Natural Gas to Chemical Plants"
-          allocation_source: "EIA_MECS_Energy"
           allocation_source_class: "Other" # nonfuel consumption
           allocation_flow:
             - "Natural Gas"
+          clean_parameter: {"221200": 'ActivityProducedBy'} #use purchases of natural gas distribution
         transport_lubricants:
           <<: *use_allocation
           names:
             - "Transportation Lubricants"
           clean_parameter: {"324110": 'ActivityProducedBy'} # purchases of refinery
 
-### Other Emissions
+## Other Emissions
   "EPA_GHGI_T_4_50": # HFCs from HCFC-22 production
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override with ghgi_year
+      # year: # override with ghgi_year
       clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI remove_HFC_kt
       fedefl_mapping: 'GHGI'
       activity_sets:
@@ -589,7 +615,7 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override with ghgi_year
+      # year: # override with ghgi_year
       fedefl_mapping: 'GHGI'
       activity_sets:
         direct:
@@ -601,8 +627,30 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override with ghgi_year
-      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI clean_HFC_fba # removes HFCs from transportation
+      # year: # override with ghgi_year
+      # This table is preprocessed across several steps in this clean fxn
+      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI clean_HFC_fba
+      clean_parameter:
+          transport_fba: 'EPA_GHGI_T_A_97' # removes HFCs from transportation
+          # 1) These transport activities are removed from ods_activity before attributing
+          # and later pulled from a separate table
+          transport_activities:
+            - 'Mobile AC'
+            - 'Comfort Cooling for Trains and Buses'
+            - 'Refrigerated Transport'
+          ods_activity: 'Refrigeration/Air Conditioning'
+          # 2) A portion of refrigeration emissions are split and direclty
+          # attributed to households based on make table
+          make_fba: 'BEA_Make_Detail_BeforeRedef'
+          make_year: 2012
+          household_make: '335222' # Household refrigerator and home freezer
+          industry_make: '333415' # Air conditioning, refrigeration manufacturing
+          # 3) Foam emissions are split based on make table and allocated separately
+          foam_activity: 'Foams'
+          polystyrene_make: '326140' # Polystyrene foam
+          urethane_make: '326150' # Urethane and other foam
+          # 4) Proportions of specific HFCs are assigned based on national total
+          flow_fba: 'EPA_GHGI_T_4_100'
       fedefl_mapping: 'GHGI'
       activity_sets:
         households:
@@ -629,8 +677,10 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override with ghgi_year
+      # year: # override with ghgi_year
       clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI split_HFCs_by_type
+      clean_parameter:
+          flow_fba: 'EPA_GHGI_T_4_100'
       fedefl_mapping: 'GHGI'
       activity_sets:
         direct:
@@ -649,7 +699,7 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override with ghgi_year
+      # year: # override with ghgi_year
       fedefl_mapping: 'GHGI'
       activity_sets:
         aluminum:
@@ -661,7 +711,7 @@ source_names:
       data_format: 'FBA'
       class: Chemicals
       geoscale_to_use: national
-      #year: # override with ghgi_year
+      # year: # override with ghgi_year
       fedefl_mapping: 'GHGI'
       activity_sets:
         magnesium:

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -308,6 +308,7 @@ source_names:
         clean_parameter: {"325310": 'ActivityProducedBy'} # Fertilizers
       grassland: *grassland # allocated based on USDA Animal operation land (acres)
 
+## Mobile Sources
   "EPA_GHGI_T_3_14": &mobile #CH4 from mobile combustion
     data_format: 'FBA'
     class: Chemicals

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -628,51 +628,39 @@ source_names:
       class: Chemicals
       geoscale_to_use: national
       # year: # override with ghgi_year
-      # This table is preprocessed across several steps in this clean fxn
-      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI clean_HFC_fba
+      clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI split_HFCs_by_type
       clean_parameter:
-          transport_fba: 'EPA_GHGI_T_A_97' # removes HFCs from transportation
-          # 1) These transport activities are removed from ods_activity before attributing
-          # and later pulled from a separate table
-          transport_activities:
-            - 'Mobile AC'
-            - 'Comfort Cooling for Trains and Buses'
-            - 'Refrigerated Transport'
-          ods_activity: 'Refrigeration/Air Conditioning'
-          # 2) A portion of refrigeration emissions are split and direclty
-          # attributed to households based on make table
-          make_fba: 'BEA_Make_Detail_BeforeRedef'
-          make_year: 2012
-          household_make: '335222' # Household refrigerator and home freezer
-          industry_make: '333415' # Air conditioning, refrigeration manufacturing
-          # 3) Foam emissions are split based on make table and allocated separately
-          foam_activity: 'Foams'
-          polystyrene_make: '326140' # Polystyrene foam
-          urethane_make: '326150' # Urethane and other foam
-          # 4) Proportions of specific HFCs are assigned based on national total
+          # Proportions of specific HFCs are assigned based on national total
           flow_fba: 'EPA_GHGI_T_4_100'
       fedefl_mapping: 'GHGI'
       activity_sets:
         households:
           names:
-            - "Refrigeration/Air Conditioning - Households"
+            - "Domestic Refrigeration"
+            - "Residential Stationary Air Conditioning"
           allocation_method: direct
           allocation_from_scale: national
         refrigerants:
           <<: *use_allocation
           names:
-            - "Refrigeration/Air Conditioning"
+            - "Commercial Refrigeration"
+            - "Industrial Process Refrigeration"
           clean_parameter: {"333415": 'ActivityProducedBy'} # Air conditioning equipment
-        foams_polystyrene:
+        air_conditioning:
           <<: *use_allocation
           names:
-            - "Foams - Polystyrene"
-          clean_parameter: {"326140": 'ActivityProducedBy'} # Polystyrene foam
-        foams_urethane:
+            - "Commercial Stationary Air Conditioning"
+          clean_parameter: {"333415": 'ActivityProducedBy'} # Air conditioning equipment
+        foams:
           <<: *use_allocation
           names:
-            - "Foams - Urethane"
-          clean_parameter: {"326150": 'ActivityProducedBy'} # Urethane and other foam
+            - "Foams"
+          clean_parameter: {"326140": 'ActivityProducedBy', # Polystyrene foam
+                            "326150": 'ActivityProducedBy'} # Urethane and other foam
+      # 'Mobile Air Conditioning' and 'Transport Refrigeration' come from
+      # different table.
+      # Intentionally left out 'Solvents', 'Aerosols', 'Fire Protection'
+
   "EPA_GHGI_T_A_97": # HFCs from Transportation
       data_format: 'FBA'
       class: Chemicals
@@ -680,6 +668,7 @@ source_names:
       # year: # override with ghgi_year
       clean_fba_before_mapping_df_fxn: !script_function:EPA_GHGI split_HFCs_by_type
       clean_parameter:
+          # Proportions of specific HFCs are assigned based on national total
           flow_fba: 'EPA_GHGI_T_4_100'
       fedefl_mapping: 'GHGI'
       activity_sets:

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -542,7 +542,7 @@ source_names:
         allocation_flow:
             - "Natural Gas"
 
-    ## TODO MISSING 'Wood Commercial' and 'Wood Industrial'
+    ##Intentionally left out 'Wood Commercial' and 'Wood Industrial'
 
   "EPA_GHGI_T_3_9":
       <<: *stationary_combustion # N2O emissions from stationary combustion

--- a/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/GHG_national_m1.yaml
@@ -27,13 +27,6 @@ _allocation_types:
             - "Table 3.2"  # Fuel (class Energy)
     clean_allocation_fba: !script_function:EIA_MECS mecs_energy_fba_cleanup
     clean_allocation_fba_w_sec: !script_function:EIA_MECS eia_mecs_energy_clean_allocation_fba_w_sec
-    helper_source: "BLS_QCEW"
-    helper_method: proportional-flagged
-    helper_source_class: "Employment"
-    # helper_source_year: # override this
-    helper_flow: None
-    helper_from_scale: national
-    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
 
   _use_allocation: &use_allocation
     # names: # override this
@@ -48,13 +41,6 @@ _allocation_types:
     allocation_from_scale: national
     clean_allocation_fba: !script_function:BEA subset_BEA_table
     # clean_parameter: # override this with dictionary like {"324110": 'ActivityProducedBy'}
-    helper_source: "BLS_QCEW"
-    helper_method: proportional
-    helper_source_class: "Employment"
-    helper_source_year: 2012
-    helper_flow: None
-    helper_from_scale: national
-    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
 
   _make_allocation: &make_allocation
     #names: # override this
@@ -69,12 +55,6 @@ _allocation_types:
     allocation_from_scale: national
     clean_allocation_fba: !script_function:BEA subset_BEA_table
     # clean_parameter: # over ride this with dictionary, like {"221100": 'ActivityConsumedBy'} # Electricity
-    helper_source: "BLS_QCEW"
-    helper_method: proportional
-    helper_source_class: "Employment"
-    helper_source_year: 2012
-    helper_from_scale: national
-    clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
 
   _lead_allocation: &lead_allocation
     names:
@@ -448,12 +428,6 @@ source_names:
         allocation_flow: ['Natural Gas']
         allocation_compartment: None
         allocation_from_scale: national
-        helper_source: "BLS_QCEW"
-        helper_method: proportional
-        helper_source_class: "Employment"
-        # helper_source_year: *ghgi_year
-        helper_from_scale: national
-        clean_helper_fba_wsec: !script_function:BLS_QCEW bls_clean_allocation_fba_w_sec
       aviation_transport:
         <<: *transport_direct
         names:


### PR DESCRIPTION
- updates GHG FBS m1 to equally allocate BEA and EIA MECS to sectors rather than use employment for attribution and to use single FBS yaml file as basis for all years
- update some attribution source data years
- update stackedbarchart() to use colors defined in visualizationessentials.csv, to include option to specify target sector level and to generalize attribution methods (direct vs attributed)
- updates to GHGI activity names