### PR TITLE
update industry_spec_key() so it is not based on sector string length

### DIFF
--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -2046,21 +2046,13 @@ class FlowBySector(_FlowBy):
         :return:
         """
         naics_key = naics.industry_spec_key(self.config['industry_spec'])
-        # TODO fix error here causing special sectors (e.g. F010) to drop
-        # when doing a summary model because lenght does not align (target_naics)
-        # does not have the right number of digits
-
-        # subset naics to those where the source_naics string length is longer
-        # than target_naics
-        naics_key_sub = naics_key.query(
-            'source_naics.str.len() >= target_naics.str.len()')
 
         fbs = self
         for direction in ['ProducedBy', 'ConsumedBy']:
             fbs = (
                 fbs
                 .rename(columns={f'Sector{direction}': 'source_naics'})
-                .merge(naics_key_sub,
+                .merge(naics_key,
                        how='left')
                 .rename(columns={'target_naics': f'Sector{direction}'})
                 .drop(columns='source_naics')

--- a/flowsa/methods/flowbysectormethods/BEA_summary_target.yaml
+++ b/flowsa/methods/flowbysectormethods/BEA_summary_target.yaml
@@ -8,8 +8,7 @@
 
 industry_spec:
   default: NAICS_3
-  '336': {default: NAICS_4}
-  '541': {default: NAICS_4}
+  NAICS_4: ['336', '541']
 # Note 531, 532, 533, and 92* are not resolved at the 3 digit NAICS
 # but they do not resolve at higher resolution and so using 3-digit NAICS
 # is sufficient

--- a/flowsa/methods/flowbysectormethods/Food_Waste_national_2018_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/Food_Waste_national_2018_m1.yaml
@@ -3,8 +3,7 @@
 
 industry_spec:
   default: NAICS_6
-  '562212': { default: NAICS_7 }
-  '562219': { default: NAICS_7 }
+  NAICS_7: ['562212', '562219']
 year: 2018
 target_naics_year: 2012
 geoscale: national

--- a/flowsa/methods/flowbysectormethods/Food_Waste_national_2018_m2.yaml
+++ b/flowsa/methods/flowbysectormethods/Food_Waste_national_2018_m2.yaml
@@ -3,8 +3,7 @@
 
 industry_spec:
   default: NAICS_6
-  '562212': { default: NAICS_7 }
-  '562219': { default: NAICS_7 }
+  NAICS_7: ['562212', '562219']
 year: 2018
 target_naics_year: 2012
 geoscale: national

--- a/flowsa/methods/flowbysectormethods/SEEA_2016_v1.yaml
+++ b/flowsa/methods/flowbysectormethods/SEEA_2016_v1.yaml
@@ -8,8 +8,7 @@
 # !include:BEA_summary_target.yaml
 industry_spec:
   default: NAICS_3
-  '336': {default: NAICS_4}
-  '541': {default: NAICS_4}
+  NAICS_4: ['336', '541']
 # industry_spec:
 #   default: NAICS_4
 target_naics_year: 2012

--- a/flowsa/methods/flowbysectormethods/SEEA_2017_kg_v1.yaml
+++ b/flowsa/methods/flowbysectormethods/SEEA_2017_kg_v1.yaml
@@ -8,8 +8,7 @@
 # !include:BEA_summary_target.yaml
 industry_spec:
   default: NAICS_3
-  '336': {default: NAICS_4}
-  '541': {default: NAICS_4}
+  NAICS_4: ['336', '541']
 # industry_spec:
 #   default: NAICS_4
 target_naics_year: 2012

--- a/flowsa/methods/flowbysectormethods/SEEA_2017_v1.yaml
+++ b/flowsa/methods/flowbysectormethods/SEEA_2017_v1.yaml
@@ -8,8 +8,7 @@
 # !include:BEA_summary_target.yaml
 industry_spec:
   default: NAICS_3
-  '336': {default: NAICS_4}
-  '541': {default: NAICS_4}
+  NAICS_4: ['336', '541']
   non_naics: ACC
 # industry_spec:
 #   default: NAICS_4

--- a/flowsa/methods/flowbysectormethods/SEEA_2017_v2.yaml
+++ b/flowsa/methods/flowbysectormethods/SEEA_2017_v2.yaml
@@ -4,8 +4,7 @@
 # !include:BEA_summary_target.yaml
 industry_spec:
   default: NAICS_3
-  '336': {default: NAICS_4}
-  '541': {default: NAICS_4}
+  NAICS_4: ['336', '541']
   non_naics: ACC
 year: &year 2017
 # industry_spec:

--- a/flowsa/methods/flowbysectormethods/USEEIO_summary_target.yaml
+++ b/flowsa/methods/flowbysectormethods/USEEIO_summary_target.yaml
@@ -8,9 +8,7 @@
 
 industry_spec:
   default: NAICS_3
-  '221': {default: NAICS_4}
-  '336': {default: NAICS_4}
-  '541': {default: NAICS_4}
+  NAICS_4: ['221', '336', '541']
 # In USEEIO models 221 (Utilities) is disaggregated to 2211, 2212, and 2213
 # '336' and '541' carry over from the BEA summary sectors
 target_naics_year: 2012

--- a/flowsa/methods/flowbysectormethods/Water_national_2015_m1.yaml
+++ b/flowsa/methods/flowbysectormethods/Water_national_2015_m1.yaml
@@ -35,8 +35,7 @@ source_names:
       cropland_attribution:
         industry_spec:
           default: NAICS_6
-          '111150': { default: NAICS_7 }
-          '111199': { default: NAICS_7 }
+          NAICS_7: ['111150', '111199']
         selection_fields:
           PrimaryActivity:
             - "Irrigation Crop"
@@ -125,9 +124,7 @@ source_names:
                       USDA_IWMS:
                         industry_spec:
                           default: NAICS_6
-                          '111150': { default: NAICS_7 }
-                          '111199': { default: NAICS_7 }
-                          '111940': { default: NAICS_7 } # hay and haylage set to NAICS7 - will update to NAICS6
+                          NAICS_7: ['111150', '111199', '111940'] # hay and haylage set to NAICS7 - will update to NAICS6
                         <<: *usda_iwms
                         activity_sets:
                           cropland_attribution-cropland-nonhay:
@@ -159,13 +156,8 @@ source_names:
       livestock_attribution:
         industry_spec:
           default: NAICS_6
-          '112130': { default: NAICS_7 }
-          '112320': { default: NAICS_7 }
-          '112390': { default: NAICS_7 }
-          '112910': { default: NAICS_7 }
-          '112920': { default: NAICS_7 }
-          '112930': { default: NAICS_7 }
-          '112990': { default: NAICS_7 }
+          NAICS_7: ['112130', '112320', '112390', '112910',
+                    '112920', '112930', '112990']
         selection_fields:
           PrimaryActivity:
             - "Livestock"

--- a/flowsa/naics.py
+++ b/flowsa/naics.py
@@ -3,6 +3,10 @@ import numpy as np
 import pandas as pd
 from . import settings
 
+naics_crosswalk = pd.read_csv(
+    f'{settings.datapath}NAICS_2012_Crosswalk.csv', dtype='object'
+)
+
 
 def industry_spec_key(
     industry_spec: dict,
@@ -41,9 +45,6 @@ def industry_spec_key(
     3.  Each dictionary is applied only to those codes matching its parent
         key (with the root dictionary being applied to all codes).
     """
-    naics_crosswalk = pd.read_csv(
-        f'{settings.datapath}NAICS_2012_Crosswalk.csv', dtype='object'
-    )
 
     naics = naics_crosswalk.assign(
         target_naics=naics_crosswalk[industry_spec['default']])

--- a/flowsa/naics.py
+++ b/flowsa/naics.py
@@ -1,9 +1,10 @@
 from typing import Literal
+import numpy as np
 import pandas as pd
 from . import settings
 
 naics_crosswalk = pd.read_csv(
-    f'{settings.datapath}NAICS_Crosswalk_TimeSeries.csv', dtype='object'
+    f'{settings.datapath}NAICS_2012_Crosswalk.csv', dtype='object'
 )
 
 
@@ -11,7 +12,7 @@ def industry_spec_key(
     industry_spec: dict,
     year: Literal[2002, 2007, 2012, 2017] = 2012
 ) -> pd.DataFrame:
-    '''
+    """
     Provides a key for mapping any set of NAICS codes to a given industry
     breakdown, specified in industry_spec. The key is a DataFrame with columns
     'source_naics' and 'target_naics'; it is 1-to-many for any NAICS codes
@@ -22,9 +23,8 @@ def industry_spec_key(
     example:
 
     industry_spec = {'default': 'NAICS_3',
-                     '112': {'default': 'NAICS_4',
-                             '1129': {'default': 'NAICS_6'}},
-                     '113': {'default': 'NAICS_4'}}
+                     'NAICS_4': ['112', '113'],
+                     'NAICS_6': ['1129']
 
     This example specification would map any set of NAICS codes to the 3-digit
     level, except that codes in 112 and 113 would be mapped to the 4-digit
@@ -44,77 +44,39 @@ def industry_spec_key(
         then any non-default keys must be NAICS codes with exactly 3 digits).
     3.  Each dictionary is applied only to those codes matching its parent
         key (with the root dictionary being applied to all codes).
-    '''
-    naics_list = (naics_crosswalk
-                  [[f'NAICS_{year}_Code']]
-                  .rename(columns={f'NAICS_{year}_Code': 'source_naics'}))
+    """
 
-    def _truncate(
-        _naics_list: pd.DataFrame,
-        _industry_spec: dict
-    ) -> pd.DataFrame:
-        '''
-        Find target NAICS by truncating any source_naics longer than the target
-        _naics_level unless industry_spec specifies a longer level for it, in
-        which case send it (recursively) into this function to be truncated to
-        the correct length.
-        '''
-        _naics_level = int(_industry_spec['default'][-1:])
-        return pd.concat([
-            (_naics_list
-             .query('source_naics.str.len() >= @_naics_level'
-                    '& source_naics.str.slice(stop=@_naics_level) '
-                    'not in @_industry_spec')
-             .assign(target_naics=lambda x: x.source_naics.str[:_naics_level])
-             ),
-            *[
-                _truncate(
-                    (_naics_list
-                     .query('source_naics.str.startswith(@naics)')),
-                    _industry_spec[naics]
-                )
-                for naics in _industry_spec if naics not in ['default',
-                                                             'non_naics']
-            ]
-        ])
+    naics = naics_crosswalk.assign(
+        target_naics=naics_crosswalk[industry_spec['default']])
+    for k, v in industry_spec.items():
+        if k not in ['default', 'non_naics']:
+            for sector in v:
+                # find column index where sector is located
+                col = np.where(naics == sector)[1][0]
 
-    truncated_naics_list = _truncate(naics_list, industry_spec)
+                naics['target_naics'] = np.where(
+                    naics[naics.columns[col]] == sector,
+                    naics[k],
+                    naics['target_naics'])
 
-    naics_list = naics_list.merge(truncated_naics_list, how='left')
+    # melt the dataframe to include source naics
+    naics_key = naics.melt(id_vars="target_naics", value_name="source_naics")
+    # add user-specified non-naics
     _non_naics = industry_spec.get('non_naics', [])
-
-    naics_key = pd.concat([
-        naics_list.query('target_naics.notna()'),
-        *[
-            (naics_list
-             .query('target_naics.isna()'
-                    '& source_naics.str.len() == @length')
-             .drop(columns='target_naics')
-             .merge(
-                 truncated_naics_list
-                 .assign(
-                     merge_key=truncated_naics_list.target_naics.str[:length])
-                 [['merge_key', 'target_naics']],
-                 how='left',
-                 left_on='source_naics',
-                 right_on='merge_key')
-             .drop(columns='merge_key')
-             )
-            for length in (naics_list.query('target_naics.isna()')
-                           .source_naics.str.len().unique())
-        ],
-        pd.DataFrame(
-            {'source_naics': _non_naics, 'target_naics': _non_naics},
-            index=[0] if isinstance(_non_naics, str) else None
-        )
-    ])
-
-    naics_key = (
-        naics_key
-        .drop_duplicates()
-        .sort_values(by=['source_naics', 'target_naics'])
-        .reset_index(drop=True)
-    )
+    naics_key = pd.concat([naics_key,
+                           pd.DataFrame({'source_naics': _non_naics,
+                                         'target_naics': _non_naics},
+                                        index=[0] if
+                                        isinstance(_non_naics, str)
+                                        else None)
+                           ])
+    # drop source_naics that are more aggregated than target_naics, reorder
+    naics_key = (naics_key[['source_naics', 'target_naics']]
+                 .dropna()
+                 .drop_duplicates()
+                 .sort_values(by=['source_naics', 'target_naics'])
+                 .reset_index(drop=True)
+                 )
 
     return naics_key
 

--- a/flowsa/naics.py
+++ b/flowsa/naics.py
@@ -47,13 +47,11 @@ def industry_spec_key(
 
     naics = naics_crosswalk.assign(
         target_naics=naics_crosswalk[industry_spec['default']])
-    for k, v in industry_spec.items():
-        if k not in ['default', 'non_naics']:
-            naics = naics.assign(
-                target_naics=naics.target_naics.mask(
-                    naics.drop(columns='target_naics').isin(v).any(axis='columns'),
-                    naics[k]
-                )
+    for level, industries in industry_spec.items():
+        if level not in ['default', 'non_naics']:
+            naics['target_naics'] = naics['target_naics'].mask(
+                naics.drop(columns='target_naics').isin(industries).any(axis='columns'),
+                naics[level]
             )
     # melt the dataframe to include source naics
     naics_key = naics.melt(id_vars="target_naics", value_name="source_naics")


### PR DESCRIPTION
- Update how target_naics are created so it is not based on the sector string length, instead determine target_naics using df of sectors by sector_length
- addresses error mapping to special sectors (e.g. F010) for summary models in [sector_aggregation](https://github.com/USEPA/flowsa/blob/b20e3f381d67e0a5b71f4832a645d4dea72d3c59/flowsa/flowby.py#L1997-L2000)
-  also reformat industry_spec dictionary so key is target naics length and sectors/values are in a list