### PR TITLE
revise generateflowbysector() to enable access to already attributed FBA sources

### DIFF
--- a/flowsa/data_source_scripts/USDA_ERS_MLU.py
+++ b/flowsa/data_source_scripts/USDA_ERS_MLU.py
@@ -114,11 +114,8 @@ def allocate_usda_ers_mlu_land_in_urban_areas(
                       'in urban land area, so subtracting out calculated '
                       'MECS and CBECS land from MLU urban land area')
     # read in the cbecs and mecs df from df_list
-    for df_i in _['attr']['attributed_sources']:
-        if (df_i['MetaSources'].str.startswith('EIA_CBECS_Land')).all():
-            cbecs = df_i
-        elif (df_i['MetaSources'].str.startswith('EIA_MECS_Land')).all():
-            mecs = df_i
+    cbecs = _['attr']['cache']['EIA_CBECS_Land']
+    mecs = _['attr']['cache']['EIA_MECS_Land']
 
     # load the federal highway administration fees dictionary
     fha_dict = get_transportation_sectors_based_on_FHA_fees()

--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -2010,24 +2010,24 @@ class FlowBySector(_FlowBy):
         # Generate FBS from method_config
         sources = method_config.pop('source_names')
 
-        # create empty list to store the fbs data, necessary as at times need
-        # to access already attributed FBA data
         fbs_list = []
         for source_name, config in sources.items():
-            fbs_source = get_flowby_from_config(
-                name=source_name,
-                config={
-                    **method_config,
-                    'method_config_keys': method_config.keys(),
-                    **get_catalog_info(source_name),
-                    **config,
-                    'attributed_sources': fbs_list
-                },
-                external_config_path=external_config_path,
-                download_sources_ok=download_sources_ok
-            ).prepare_fbs(external_config_path=external_config_path)
+            if source_name in method_config['cache']:
+                fbs_source = method_config['cache'][source_name].copy()
+            else:
+                fbs_source = get_flowby_from_config(
+                    name=source_name,
+                    config={
+                        **method_config,
+                        'method_config_keys': method_config.keys(),
+                        **get_catalog_info(source_name),
+                        **config
+                    },
+                    external_config_path=external_config_path,
+                    download_sources_ok=download_sources_ok
+                ).prepare_fbs(external_config_path=external_config_path)
             fbs_list.append(fbs_source)
-        fbs = pd.concat(fbs_list, ignore_index=True, sort=False)
+        fbs = pd.concat(fbs_list)
 
         fbs.full_name = method
         fbs.config = method_config

--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -2010,20 +2010,24 @@ class FlowBySector(_FlowBy):
         # Generate FBS from method_config
         sources = method_config.pop('source_names')
 
-        fbs = pd.concat([
-            get_flowby_from_config(
+        # create empty list to store the fbs data, necessary as at times need
+        # to access already attributed FBA data
+        fbs_list = []
+        for source_name, config in sources.items():
+            fbs_source = get_flowby_from_config(
                 name=source_name,
                 config={
                     **method_config,
                     'method_config_keys': method_config.keys(),
                     **get_catalog_info(source_name),
-                    **config
+                    **config,
+                    'attributed_sources': fbs_list
                 },
                 external_config_path=external_config_path,
                 download_sources_ok=download_sources_ok
             ).prepare_fbs(external_config_path=external_config_path)
-            for source_name, config in sources.items()
-        ])
+            fbs_list.append(fbs_source)
+        fbs = pd.concat(fbs_list, ignore_index=True, sort=False)
 
         fbs.full_name = method
         fbs.config = method_config

--- a/flowsa/metadata.py
+++ b/flowsa/metadata.py
@@ -97,6 +97,7 @@ def return_fbs_method_data(source_name, config):
     # Create empty dictionary for storing meta data
     meta = {}
     # subset the FBS dictionary into a dictionary of source names
+    # todo: need to modify to read cached sources (see land_national fbs)
     fb = config['source_names']
     # initiate nested dictionary
     meta['primary_source_meta'] = {}
@@ -110,9 +111,13 @@ def return_fbs_method_data(source_name, config):
                 meta['primary_source_meta'][k] = add_stewi_metadata(
                     v['inventory_dict'])
             continue
-        if v.get('data_format') in ('FBS', 'FBS_outside_flowsa'):
-            meta['primary_source_meta'][k] = \
-                getMetadata(k, category='FlowBySector')
+        try:
+            if v.get('data_format') in ('FBS', 'FBS_outside_flowsa'):
+                meta['primary_source_meta'][k] = \
+                    getMetadata(k, category='FlowBySector')
+                continue
+        except AttributeError:
+            log.warning(f'Missing config info for {k}')
             continue
         # append source and year
         year = config['year'] if v.get('year') is None else v.get('year')

--- a/flowsa/methods/flowbysectormethods/Land_national_2012.yaml
+++ b/flowsa/methods/flowbysectormethods/Land_national_2012.yaml
@@ -9,7 +9,7 @@ year: 2015
 target_naics_year: 2012
 geoscale: national
 
-source_names:
+sources_to_cache:
   EIA_CBECS_Land: # commercial land use
     fedefl_mapping: EIA_CBECS_Land
     year: 2012
@@ -44,6 +44,10 @@ source_names:
           Employment_national_2014:
             data_format: FBS
             year: 2014
+
+source_names:
+  EIA_CBECS_Land:
+  EIA_MECS_Land:
   "BLM_PLS":
     fedefl_mapping: BLM_PLS
     year: 2012

--- a/flowsa/methods/flowbysectormethods/Land_national_2012.yaml
+++ b/flowsa/methods/flowbysectormethods/Land_national_2012.yaml
@@ -127,36 +127,24 @@ source_names:
           - 'Land in defense and industrial areas'
           - 'Land in rural parks and wildlife areas'
         attribution_method: direct
-#      rural_transportation:
-#        selection_fields:
-#         PrimaryActivity:
-#          - 'Land in rural transportation facilities'
-#        attribution_method: allocation_function
-#        attribution_source: !script_function:USDA_ERS_MLU allocate_usda_ers_mlu_land_in_rural_transportation_areas
-#        literature_sources: {
-#          "urban_land_use_for_airports": "2020",
-#          "urban_land_use_for_railroads": "2020",
-#          "transportation_sectors_based_on_FHA_fees": "1997"}
-#        geoscale: national
-#      urban:
-#        selection_fields:
-#         PrimaryActivity:
-#          - 'Land in urban areas'
-#        attribution_method: allocation_function
-#        attribution_source: !script_function:USDA_ERS_MLU allocate_usda_ers_mlu_land_in_urban_areas
-#        literature_sources: {
-#          "area_of_urban_land_occupied_by_houses_2013": "2017",
-#          "transportation_sectors_based_on_FHA_fees": "1997",
-#          "urban_land_use_for_airports": "2020",
-#          "urban_land_use_for_railroads": "2020",
-#          "open_space_fraction_of_urban_area": "2020"}
-#        geoscale: national
-#      other:
-#        selection_fields:
-#         PrimaryActivity:
-#          - 'Other land'
-#        attribution_method: allocation_function
-#        attribution_source: !script_function:USDA_ERS_MLU allocate_usda_ers_mlu_other_land
-#        literature_sources: {
-#          "area_of_rural_land_occupied_by_houses_2013": "2017" }
-#        geoscale: national
+      rural_transportation:
+        selection_fields:
+         PrimaryActivity:
+          - 'Land in rural transportation facilities'
+        clean_fba_w_sec: !script_function:USDA_ERS_MLU allocate_usda_ers_mlu_land_in_rural_transportation_areas
+        geoscale: national
+        attribution_method: direct
+      urban:
+        selection_fields:
+         PrimaryActivity:
+          - 'Land in urban areas'
+        clean_fba_w_sec: !script_function:USDA_ERS_MLU allocate_usda_ers_mlu_land_in_urban_areas
+        geoscale: national
+        attribution_method: direct
+      other:
+        selection_fields:
+         PrimaryActivity:
+          - 'Other land'
+        clean_fba_w_sec: !script_function:USDA_ERS_MLU allocate_usda_ers_mlu_other_land
+        geoscale: national
+        attribution_method: direct


### PR DESCRIPTION
Enable ability in FBS methods to access already attributed FBA source data. 

Necessary for Land FBS method for [urban activity set](https://github.com/USEPA/flowsa/blob/43024b45aed72c17cd949d008d4513e6aa5451fb/flowsa/methods/flowbysectormethods/Land_national_2012.yaml#L137-L143), need to access the already attributed data [CBECS](https://github.com/USEPA/flowsa/blob/43024b45aed72c17cd949d008d4513e6aa5451fb/flowsa/methods/flowbysectormethods/Land_national_2012.yaml#L13-L28) and [MECS](https://github.com/USEPA/flowsa/blob/43024b45aed72c17cd949d008d4513e6aa5451fb/flowsa/methods/flowbysectormethods/Land_national_2012.yaml#L29-L46)

- revise generateflowbysector() to include the already attributed data in the method config. 