### PR TITLE
skip `select_by_fields` when using activity_sets

### DIFF
--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -394,7 +394,8 @@ class _FlowBy(pd.DataFrame):
     def select_by_fields(
         self: FB,
         selection_fields: dict = None,
-        exclusion_fields: dict = None
+        exclusion_fields: dict = None,
+        skip_select_by: bool = False,
     ) -> FB:
         '''
         Filter the calling FlowBy dataset according to the 'selection_fields'
@@ -436,11 +437,8 @@ class _FlowBy(pd.DataFrame):
         Similarly, can use 'exclusion_fields' to remove particular data in the
         same manner.
         '''
-        if 'activity_sets' in self.config:
-            # When activity_sets are present, select_by_fields has already
-            # been called
+        if skip_select_by:
             return self
-
         exclusion_fields = (exclusion_fields or
                             self.config.get('exclusion_fields', {}))
         exclusion_fields = {k: [v] if not isinstance(v, (list, dict)) else v

--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -436,6 +436,11 @@ class _FlowBy(pd.DataFrame):
         Similarly, can use 'exclusion_fields' to remove particular data in the
         same manner.
         '''
+        if 'activity_sets' in self.config:
+            # When activity_sets are present, select_by_fields has already
+            # been called
+            return self
+
         exclusion_fields = (exclusion_fields or
                             self.config.get('exclusion_fields', {}))
         exclusion_fields = {k: [v] if not isinstance(v, (list, dict)) else v

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -678,7 +678,8 @@ class FlowByActivity(_FlowBy):
     def prepare_fbs(
             self: 'FlowByActivity',
             external_config_path: str = None,
-            download_sources_ok: bool = True
+            download_sources_ok: bool = True,
+            skip_select_by: bool = False,
             ) -> 'FlowBySector':
 
         from flowsa.flowbysector import FlowBySector
@@ -688,7 +689,9 @@ class FlowByActivity(_FlowBy):
                 return (
                     pd.concat([
                         fba.prepare_fbs(
-                            external_config_path=external_config_path, download_sources_ok=download_sources_ok)
+                            external_config_path=external_config_path,
+                            download_sources_ok=download_sources_ok,
+                            skip_select_by=True)
                         for fba in (
                             self
                             .select_by_fields()
@@ -705,9 +708,10 @@ class FlowByActivity(_FlowBy):
         return FlowBySector(
             self
             .function_socket('clean_fba_before_mapping')
-            .select_by_fields()
+            .select_by_fields(skip_select_by=skip_select_by)
             .function_socket('estimate_suppressed')
-            .select_by_fields(selection_fields=self.config.get(
+            .select_by_fields(skip_select_by=skip_select_by,
+                              selection_fields=self.config.get(
                 'selection_fields_after_data_suppression_estimation', 'null'))
             .convert_units_and_flows()  # and also map to flow lists
             .function_socket('clean_fba')


### PR DESCRIPTION
This avoids duplicating the `select_by_fields` step for `activity_sets` which can drop data when Activity or flow names are changed