### PR TITLE
option to generate FBS that contains activity cols and sector name cols

### DIFF
--- a/flowsa/common.py
+++ b/flowsa/common.py
@@ -73,8 +73,9 @@ def load_crosswalk(crosswalk_name):
     Used to load the crosswalks:
 
     'NAICS_Crosswalk_TimeSeries', 'NAICS_2012_Crosswalk',
-    'Sector_2012_Names', 'Household_SectorCodes', 'Government_SectorCodes',
-    'NAICS_to_BEA_Crosswalk_2012', 'NAICS_to_BEA_Crosswalk_2017'
+    'Sector_2012_Names', 'Sector_2017_Names','Household_SectorCodes',
+    'Government_SectorCodes', 'NAICS_to_BEA_Crosswalk_2012',
+    'NAICS_to_BEA_Crosswalk_2017'
 
     as a dataframe
 

--- a/flowsa/flowbyactivity.py
+++ b/flowsa/flowbyactivity.py
@@ -680,9 +680,16 @@ class FlowByActivity(_FlowBy):
             external_config_path: str = None,
             download_sources_ok: bool = True,
             skip_select_by: bool = False,
+            retain_activity_columns: bool = False,
             ) -> 'FlowBySector':
 
         from flowsa.flowbysector import FlowBySector
+
+        # drop the activity columns in the FBS unless method yaml specifies
+        # to keep them
+        drop_cols = ['ActivityProducedBy', 'ActivityConsumedBy']
+        if retain_activity_columns:
+            drop_cols = []
 
         if 'activity_sets' in self.config:
             try:
@@ -691,7 +698,8 @@ class FlowByActivity(_FlowBy):
                         fba.prepare_fbs(
                             external_config_path=external_config_path,
                             download_sources_ok=download_sources_ok,
-                            skip_select_by=True)
+                            skip_select_by=True,
+                            retain_activity_columns=retain_activity_columns)
                         for fba in (
                             self
                             .select_by_fields()
@@ -718,7 +726,7 @@ class FlowByActivity(_FlowBy):
             .convert_to_geoscale()
             .attribute_flows_to_sectors(external_config_path=external_config_path,
                                         download_sources_ok=download_sources_ok)  # recursive call to prepare_fbs
-            .drop(columns=['ActivityProducedBy', 'ActivityConsumedBy'])
+            .drop(columns=drop_cols)
             .aggregate_flowby()
             .function_socket('clean_fbs_after_aggregation')
         )

--- a/flowsa/flowbysector.py
+++ b/flowsa/flowbysector.py
@@ -279,10 +279,12 @@ class FlowBySector(_FlowBy):
         return fbs
 
     def prepare_fbs(
-        self: 'FlowBySector',
-        external_config_path: str = None,
-        download_sources_ok: bool = True
+            self: 'FlowBySector',
+            external_config_path: str = None,
+            download_sources_ok: bool = True,
+            **kwargs
     ) -> 'FlowBySector':
+
         if 'activity_sets' in self.config:
             try:
                 return (

--- a/flowsa/flowbysector.py
+++ b/flowsa/flowbysector.py
@@ -120,7 +120,7 @@ class FlowBySector(_FlowBy):
             external_config_path: str = None,
             download_sources_ok: bool = settings.DEFAULT_DOWNLOAD_IF_MISSING,
             retain_activity_columns: bool = False,
-            append_sector_name=False,
+            append_sector_names=False,
             **kwargs
     ) -> 'FlowBySector':
         '''
@@ -212,7 +212,7 @@ class FlowBySector(_FlowBy):
         fbs = fbs.assign(**dict.fromkeys(dq_cols, None))
 
         # append the sector names to the FBS if specified
-        if append_sector_name:
+        if append_sector_names:
             cw = load_crosswalk(
                 f'Sector_{fbs.config["target_naics_year"]}_Names')
             for s in ['Produced', 'Consumed']:


### PR DESCRIPTION
generate an FBS that has columns of the original activity names and/or columns of the sector/naics names

can generate by running the example code

```
import flowsa.flowbysector
import pandas as pd

fbsmethod = 'Water_national_2015_m1'

fbs = pd.DataFrame(flowsa.flowbysector.FlowBySector.generateFlowBySector(
    fbsmethod,
    download_sources_ok=True,
    retain_activity_columns=True,
    append_sector_names=True
))
```
